### PR TITLE
Replace icon for change language button

### DIFF
--- a/dev/src/components/LanguageSwitch.tsx
+++ b/dev/src/components/LanguageSwitch.tsx
@@ -15,7 +15,7 @@ export const LanguageSwitch: FC = () => {
 					_href={`/en${location.pathname}`}
 					_label="Switch to English"
 					_hideLabel
-					_icon="fa-solid fa-language"
+					_icon="codicon codicon-globe"
 					_tooltipAlign="left"
 					_variant="ghost"
 				/>
@@ -24,7 +24,7 @@ export const LanguageSwitch: FC = () => {
 					_href={`${location.pathname.replace(/^\/en/, '')}`}
 					_label="Zu Deutsch wechseln"
 					_hideLabel
-					_icon="fa-solid fa-language"
+					_icon="codicon codicon-globe"
 					_tooltipAlign="left"
 					_variant="ghost"
 				/>


### PR DESCRIPTION
Es ist nicht der selbe Icon, aber so müssen wir keinen zweiten Icon-Font laden. Und der Icon passt zu den nebenstehenden Icons.
Passt das also Lösung?