### PR TITLE
docs: removed outdated warning and enhanced tree component documentation

### DIFF
--- a/docs/30-components/tree.mdx
+++ b/docs/30-components/tree.mdx
@@ -15,11 +15,7 @@ import { ExampleLink } from '@site/src/components/ExampleLink';
 
 Synonyme: List, Navigation
 
-<kol-alert _type="warning" _variant="card">
-	<kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
-</kol-alert>
-
-Die Komponente **Tree** stellt eine hierarchische Liste dar. Jedes Element in der Hierarchie kann Kindelemente haben, und Elemente, die Kinder haben, können erweitert oder reduziert werden, um die Kinder anzuzeigen oder zu verbergen.
+Die **Tree**-Komponente stellt eine hierarchische Liste dar, in der jedes Element untergeordnete Einträge enthalten kann. Elemente mit Kindelementen lassen sich ein- oder ausklappen, um die untergeordnete Ebene anzuzeigen oder auszublenden.
 
 ### Code
 
@@ -61,21 +57,25 @@ Die Komponente **Tree** stellt eine hierarchische Liste dar. Jedes Element in de
 
 ## Verwendung
 
-Eine **Tree**-Komponente wird verwendet, um komplexe, hierarchische Datenstrukturen visuell darzustellen und zu navigieren. Sie ermöglicht es Benutzern, sich effizient durch verschachtelte Informationen zu bewegen und bietet eine klare Übersicht über die Beziehungen zwischen den verschiedenen Elementen. Solche Komponenten sind nützlich in Anwendungen wie Navigatoren, Organisationsdiagrammen, Produktkatalogen und überall dort, wo eine strukturierte Darstellung von Daten erforderlich ist.
-Das **`_label`**-Attribut wird für den Text und das **`_href`**-Attribut für den Link des Navigationspunkts genutzt. Zusätzlich lässt sich das aktive Element über das Attribut **`_active`** steuern, sowie im Standardzustand über das **`_open`** Attribut öffnen.
+Die Tree-Komponente wird verwendet, um komplexe, hierarchisch aufgebaute Daten visuell darzustellen und benutzerfreundlich navigierbar zu machen. Sie ermöglicht es Nutzerinnen und Nutzern, sich effizient durch verschachtelte Strukturen zu bewegen und liefert dabei eine klare Übersicht über die Beziehungen zwischen über- und untergeordneten Elementen.
+
+Typische Einsatzbereiche sind z. B. Navigationsleisten, Organisationsstrukturen, Dateiverzeichnisse oder Produktkataloge – überall dort, wo Inhalte strukturiert und mehrstufig angezeigt werden sollen.
+
+Jeder Navigationspunkt wird über das Attribut `_label` beschriftet und kann optional über `_href` mit einem Ziel verlinkt werden. Mit dem Attribut `_active` lässt sich ein Element als aktuell aktiv markieren, während `_open` steuert, ob ein Element beim initialen Laden aufgeklappt ist.
 
 ### Tastatursteuerung
 
-| Taste          | Funktion                                                                                                                                                                                                                                                                                                                                                         |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Tab`          | Der Tree lässt sich zudem mittels Tabulator-Taste fokussieren.                                                                                                                                                                                                                                                                                                   |
-| `Pfeil-Tasten` | Die Pfeiltasten können für die Navigation der Elemente im Tree verwendet werden, um das Untermenü zu öffnen oder zu schließen sowie zwischen den Navigationspunkten zu springen. Dabei wird die linke/rechte Pfeiltaste für das Öffnen oder Schließen des Untermenüs und die oben/unten Pfeiltaste für das Wechseln zwischen den Navigationselementen verwendet. |
-| `Enter`        | Selektiert das derzeitig fokussierte Element und navigiert, falls das **`_href`**-Attribut gesetzt wurde.                                                                                                                                                                                                                                                        |
-| `Home`         | Fokussiert das erste Element in der Tree-Komponenten                                                                                                                                                                                                                                                                                                             |
-| `End`          | Fokussiert das letzte Element in der Tree-Komponenten                                                                                                                                                                                                                                                                                                            |
-| `*`            | Öffnet, alle Geschwister-Elemente der derzeitig fokussierten Ebene                                                                                                                                                                                                                                                                                               |
-
-Zusätzlich können Elemente in der **Tree**-Komponente mit Alphanumerischen-Tasten gesucht und fokussiert werden. In dem oben gennanten Beispiel, würde durch die Taste `S` das Element mit dem **`_label`** `Subpage 1` fokussiert werden und bei wiederholten Drücken der selben Taste die `Subpage 2`, etc.
+| Taste          | Funktion                                                                                                                                                                                                                      |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab`          | Fokussiert die Tree-Komponente, sodass sie per Tastatur bedient werden kann.                                                                                                                                                  |
+| `↑ / ↓`        | Navigiert zwischen sichtbaren Elementen auf derselben Ebene.                                                                                                                                                                  |
+| `→`            | Öffnet das Untermenü des aktuell fokussierten Elements (sofern vorhanden).                                                                                                                                                    |
+| `←`            | Schließt das Untermenü (sofern geöffnet) oder verschiebt den Fokus auf das übergeordnete Element.                                                                                                                             |
+| `Enter`        | Aktiviert das aktuell fokussierte Element. Wenn ein `_href`-Attribut vorhanden ist, erfolgt eine Navigation zum Ziel.                                                                                                         |
+| `Pos1`         | Fokussiert das erste Element der Tree-Komponente.                                                                                                                                                                             |
+| `Ende`         | Fokussiert das letzte Element der Tree-Komponente.                                                                                                                                                                            |
+| `*`            | Öffnet alle geschlossenen Geschwisterelemente auf der aktuell fokussierten Ebene.                                                                                                                                             |
+| Alphanumerisch | Durch Eingabe eines Buchstabens wird das nächste Element fokussiert, dessen `_label` mit diesem Zeichen beginnt. Bei wiederholtem Drücken desselben Buchstabens wird zum jeweils nächsten passenden Element weitergesprungen. |
 
 ## Links und Referenzen
 


### PR DESCRIPTION
This pull request refines the documentation for the `Tree` component in `docs/30-components/tree.mdx`. The changes improve clarity, update the keyboard navigation guide, and enhance the description of the component's usage and functionality.

### Documentation Improvements:

* **Simplified Component Description**: The description of the `Tree` component was rewritten for better readability and conciseness, removing the preview warning and emphasizing its hierarchical structure and expand/collapse functionality.
* **Enhanced Usage Details**: The usage section was updated to provide clearer examples of where the `Tree` component is applicable (e.g., navigation bars, file directories). It also specifies how attributes like `_label`, `_href`, `_active`, and `_open` are used.

### Keyboard Navigation Updates:

* **Revised Key Descriptions**: The keyboard navigation guide was rewritten for improved clarity. It now uses clearer terminology, such as `↑ / ↓` for navigation within the same level and `→`/`←` for expanding/collapsing menus. Additional details include how alphanumeric keys can be used for quick navigation.

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [x] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
