### PR TITLE
docs: remove draft warning from combobox

### DIFF
--- a/docs/30-components/combobox.mdx
+++ b/docs/30-components/combobox.mdx
@@ -14,10 +14,6 @@ import { ExampleLink } from '@site/src/components/ExampleLink';
 
 Synonyme: Autocomplete, Select, Dropdown
 
-<kol-alert _type="warning" _variant="card">
-	<kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
-</kol-alert>
-
 Die **Combobox**-Komponente erzeugt eine Auswahlliste, die ein Eingabefeld mit einer darunter angezeigten Liste von auswählbaren Optionen kombiniert.
 
 ## Konstruktion


### PR DESCRIPTION
This pull request removes a warning about the accessibility testing status of the `Combobox` component from its documentation. The change simplifies the documentation by eliminating the alert and badge elements.

Documentation updates:

* [`docs/30-components/combobox.mdx`](diffhunk://#diff-77e220d78d782325d0e265c7bb0b0fcc0414a73fc796677775779b8b9abb1806L17-L20): Removed a warning card that highlighted the `Combobox` component as untested for accessibility, along with a preview badge. This makes the documentation cleaner and removes the cautionary note about production use.

The A11y and PO reviews will only take place after all other DoD steps have been completed by the Developer:
- [x] Meaningful pull request title for the release notes
- [x] Pull request is linked to an issue and all changes relate to the issue
- [x] Tests to protect this code implemented (if applicable)
- [x] Manual test performed successfully (if applicable)
- [x] Documentation or migration has been updated (if applicable)
