### PR TITLE
Remove preview notice in Drawer docs

### DIFF
--- a/docs/30-components/drawer.mdx
+++ b/docs/30-components/drawer.mdx
@@ -14,11 +14,6 @@ import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
 
 Synonyme: Corner Dialog, Prompt
-
-<kol-alert _type="warning" _variant="card">
-	<kol-badge _color="#476af5" _label="Preview"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da die Barrierefreiheitstests noch ausstehen. Die verschiedenen Tests können aufgrund der Modularität bei neuen Komponenten und Funktionalitäten meist erst nach einem Release erfolgen. Wir empfehlen daher, die Komponente noch nicht in Produktion zu verwenden.
-</kol-alert>
-
 Mithilfe der **Drawer**-Komponente können zusätzliche Informationen oder auch Navigationselemente in einem ausklappbaren Seitenfenster angezeigt werden. Ein offener Drawer kann via ESC geschlossen werden.
 
 Die **Drawer**-Komponente ist standardmäßig versteckt. Sie wird i.d.R. erst nach Klick auf einen Button oder sonstigem Trigger angezeigt bzw. controlled mit dem Attribut `_open` gesteuert.


### PR DESCRIPTION
## Summary
- remove the preview warning from the Drawer documentation

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874eea0ff20832c98346ba3a2b82fa8