### PR TITLE
fix: Sanitize HTML output in PropertiesOverview component to prevent invalid HTML

### DIFF
--- a/src/components/PropertiesOverview.tsx
+++ b/src/components/PropertiesOverview.tsx
@@ -136,7 +136,17 @@ export const PropertiesOverview: FC = () => {
 									backgroundColor: types.length > 1 ? '#fbc' : undefined,
 								}}
 								dangerouslySetInnerHTML={{
-									__html: types.join('<hr/>'),
+									// This type causes invalid HTML: "undefined | { onCreate?: EventCallback<Event> | undefined; } & { onSelect?: EventValueOrEventCallback<MouseEvent | KeyboardEvent | CustomEvent<any> | PointerEvent, number> | undefined; }"
+									__html: types
+										.map((type) =>
+											type
+												.replace(/&/g, '&amp;')
+												.replace(/</g, '&lt;')
+												.replace(/>/g, '&gt;')
+												.replace(/"/g, '&quot;')
+												.replace(/'/g, '&#39;')
+										)
+										.join('<hr/>'),
 								}}
 							/>
 						</tr>


### PR DESCRIPTION
This pull request improves the way type information is rendered in the `PropertiesOverview` component to prevent invalid HTML and potential security issues. The main change is that type strings are now properly escaped before being inserted into the DOM.

Rendering and security improvements:

* [`src/components/PropertiesOverview.tsx`](diffhunk://#diff-23db9055b7783c8a6c884ca4803c3856f306861fd33da67addfc7083c5bf1aa6L139-R149): Escaped special HTML characters in the `types` array before joining and rendering, preventing invalid HTML and reducing XSS risk.