### PR TITLE
refactor: use translate function for version hint

### DIFF
--- a/src/components/DocumentationVersionHint.tsx
+++ b/src/components/DocumentationVersionHint.tsx
@@ -1,27 +1,32 @@
-import Translate from '@docusaurus/Translate';
+import { translate } from '@docusaurus/Translate';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { KolLink } from '@public-ui/react';
 import React, { type ReactNode } from 'react';
 
 export default function DocumentationVersionHint(): ReactNode {
 	const { i18n } = useDocusaurusContext();
+	const versionHint = translate(
+		{
+			id: 'custom.docs-version-hint',
+			message: 'Wir haben KoliBri - Public UI {version} veröffentlicht. Für die LTS Version, siehe {link}.',
+		},
+		{ version: 'VERSION', link: 'LINK' }
+	);
+	const [beforeVersion, afterVersion] = versionHint.split('VERSION');
+	const [beforeLink, afterLink] = afterVersion.split('LINK');
 	return (
 		<p className="version-hint">
-			<Translate
-				id="custom.docs-version-hint"
-				values={{
-					link: (
-						<KolLink
-							style={{
-								padding: '0 .25rem',
-							}}
-							_href={`https://public-ui.github.io/v2${i18n.currentLocale === 'en' ? '/en' : ''}`}
-							_label={'https://public-ui.github.io/v2'}
-						></KolLink>
-					),
-					version: <b>v3</b>,
+			{beforeVersion}
+			<b>v3</b>
+			{beforeLink}
+			<KolLink
+				style={{
+					padding: '0 .25rem',
 				}}
-			/>
+				_href={`https://public-ui.github.io/v2${i18n.currentLocale === 'en' ? '/en' : ''}`}
+				_label={'https://public-ui.github.io/v2'}
+			></KolLink>
+			{afterLink}
 		</p>
 	);
 }


### PR DESCRIPTION
## Summary
- replace `<Translate>` component with `translate` function in version hint
- interpolate version and link placeholders manually

## Testing
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc9e728a78832b8333173bbabf7cd8