### PR TITLE
368 (exampleLink) fix link to examples

### DIFF
--- a/src/components/ExampleLink.tsx
+++ b/src/components/ExampleLink.tsx
@@ -18,7 +18,7 @@ export const ExampleLink: FC<ComponentProps> = ({ component }) => {
 				})}
 			</Heading>
 			<KolLink
-				_href={`/${VERSION_ID}/sample-react/#/${component}`}
+				_href={`${VERSION_ID}/#/${component}`}
 				_label={translate({
 					id: 'custom.view-component-example',
 					message: 'Beispiel der Komponente ansehen',

--- a/src/shares/version.ts
+++ b/src/shares/version.ts
@@ -1,1 +1,1 @@
-export const VERSION_ID = 'v2'; // should be V3, but we don't have a V3 sample app deployed yet.
+export const VERSION_ID = 'https://develop--kolibri-public-ui.netlify.app';


### PR DESCRIPTION
Refs: #368 

Der Link **Beispiel der Komponente ansehen** wurde korrigiert. 

Anpassungen:
- version.ts
  - https://develop--kolibri-public-ui.netlify.app -> Zeigt jetzt auf v3
- ExampleLink.tsx
  - `${VERSION_ID}/#/${component}` -> `/samples-react/` entfernt