### PR TITLE
368 (exampleLink) fix example link

### DIFF
--- a/src/components/ExampleLink.tsx
+++ b/src/components/ExampleLink.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { KolLink } from '@public-ui/react';
 import { translate } from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
-import { VERSION_ID } from '@site/src/shares/version';
+import { NETLIFLY_LINK } from '@site/src/shares/version';
 
 interface ComponentProps {
 	component: string;
@@ -18,7 +18,7 @@ export const ExampleLink: FC<ComponentProps> = ({ component }) => {
 				})}
 			</Heading>
 			<KolLink
-				_href={`/${VERSION_ID}/sample-react/#/${component}`}
+				_href={`${NETLIFLY_LINK}/#/${component}`}
 				_label={translate({
 					id: 'custom.view-component-example',
 					message: 'Beispiel der Komponente ansehen',

--- a/src/shares/version.ts
+++ b/src/shares/version.ts
@@ -1,1 +1,2 @@
 export const VERSION_ID = 'v2';
+export const NETLIFLY_LINK = 'https://release-2--kolibri-public-ui.netlify.app/';


### PR DESCRIPTION
Refs: #368 

Der Link **Beispiel der Komponente ansehen** wurde korrigiert. 

Anpassungen:
- version.ts 
  - Neue Konstante erstellt: `NETLIFY_LINK` zeigt auf https://release-2--kolibri-public-ui.netlify.app
- ExampleLink.tsx
  - `${VERSION_ID}/#/${component}` -> `/samples-react/` entfernt