### PR TITLE
fix(popover button): remove untested marker

### DIFF
--- a/docs/30-components/popover-button.mdx
+++ b/docs/30-components/popover-button.mdx
@@ -11,9 +11,6 @@ import Readme from '../../readmes/popover-button/readme.md';
 
 # PopoverButton
 
-<kol-badge
-	_label="untested"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da der vollständige Barrierefreiheitstest noch aussteht. Der vollständige Test kann bei neuen Komponenten und Funktionalitäten auch erst nach einem abgeschlossenen Release erfolgen.
-
 Der PopoverButton ist eine Komponente, die einen Button mit einem zugehörigen Popover-Menü kombiniert. Das Popover wird durch Klicken auf den Button ein- und ausgeblendet. Die Beschriftung des Buttons kann über das `_label`-Attribut festgelegt werden. Die Position des Popovers lässt sich über `_popover-align` steuern, wobei das Popover wahlweise oberhalb, rechts, unterhalb oder links vom Button platziert werden kann.
 
 Der PopoverButton eignet sich besonders für:


### PR DESCRIPTION
This pull request makes a minor documentation update to the `PopoverButton` component. The badge marking the component as untested and the related note about accessibility testing have been removed from the documentation.