### PR TITLE
docs: dialog aus samplePreviews entfernen

### DIFF
--- a/src/components/samplePreviews/Dialog.tsx
+++ b/src/components/samplePreviews/Dialog.tsx
@@ -1,6 +1,0 @@
-import React from 'react';
-import { KolImage } from '@public-ui/react-v19';
-
-const Dialog = () => <KolImage _src="/assets/samples/modal.png" _alt="" _sizes="20vw" />;
-
-export default Dialog;

--- a/src/components/samplePreviews/version/current.tsx
+++ b/src/components/samplePreviews/version/current.tsx
@@ -46,10 +46,6 @@ export const COMPONENTS_CURRENT = [
 		loadComponent: () => lazy(() => import('../Details')),
 	},
 	{
-		name: 'dialog',
-		loadComponent: () => lazy(() => import('../Dialog')),
-	},
-	{
 		name: 'drawer',
 		loadComponent: () => lazy(() => import('../Drawer')),
 	},

--- a/src/shares/synonyms.ts
+++ b/src/shares/synonyms.ts
@@ -8,7 +8,6 @@ export const COMPONENT_SYNONYMS: ComponentSynonyms = {
 	avatar: ['Persona'],
 	combobox: ['Autocomplete', 'Select', 'Dropdown'],
 	details: ['Disclosure', 'Collapse', 'Summary Detail'],
-	dialog: ['Modal', 'Modal dialog', 'Corner Dialog', 'Prompt'],
 	image: ['Img', 'Thumbnail'],
 	'input-date': ['Date Picker', 'Datetime Picker', 'Week Picker Month Picker', 'Time Picker', 'Calendar'],
 	'input-file': ['Upload', 'File Uploader', 'File Picker', 'File Selector'],


### PR DESCRIPTION
Den Dialog gibt es in der aktuellen Version von KoliBri nicht mehr.

Diese Änderung entfernt den Dialog aus der Komponentenübersicht, um eventuelle Verwirrung der Nutzer zu reduzieren.

Reference: https://public-ui.github.io/v2/docs/components/dialog
Reference: https://public-ui.github.io/docs/components/dialog