### PR TITLE
Add English translations for component docs

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/abbr.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/abbr.mdx
@@ -1,0 +1,49 @@
+---
+title: Abbr
+description: Description, specification and examples for the Abbr component.
+---
+
+import Readme from '/readmes/abbr/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Abbr
+
+The **Abbr** component implements the HTML tag `abbr` to represent an abbreviation. Optionally, a label can be passed, which is displayed in brackets after the abbreviation.
+
+## Construction
+
+### Code
+
+```html
+<p>Ich <kol-abbr _label="zum Beispiel">z. B.</kol-abbr> bin eine Abkürzung mit Label.</p>
+<p>Ich <kol-abbr>z. B.</kol-abbr> bin eine Abkürzung ohne Label.</p>
+```
+
+### Example
+
+<p>Ich <kol-abbr _label="zum Beispiel">z. B.</kol-abbr> bin eine Abkürzung mit Label.</p>
+<p>Ich <kol-abbr>z. B.</kol-abbr> bin eine Abkürzung ohne Label.</p>
+
+## Usage
+
+### Specify the description of the abbreviation
+
+The term or explanation is passed via the **`_label`** attribute, the abbreviation or the term worthy of explanation comes between the tags in the HTML.
+
+## Links and references
+
+- <kol-link _href="https://developer.mozilla.org/de/docs/Web/HTML/Element/abbr" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="abbr" />
+
+## Live editor
+
+<LiveEditorCompact component="abbr" />
+
+## Examples
+
+<Configurator component="abbr" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/accordion.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/accordion.mdx
@@ -1,0 +1,188 @@
+---
+title: Accordion
+description: Description, specification and examples for the Accordion component.
+---
+
+import Readme from '/readmes/accordion/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Accordion
+
+Synonyms: Collapse
+
+The **Accordion** component is a drop-down menu. If you click on the header area, consisting of the icon and heading, the content opens with additional information. It is therefore an interactive navigation element that is used to display extensive content in a space-saving manner.
+
+Accordions are always used when content associated with a thematic general term needs to be displayed or hidden. They allow more detailed information about a general term than would actually be useful for reasons of clarity. You leave it to the visitors themselves whether they want to display this information.
+
+## Construction
+
+### Code
+
+```html
+<div class="grid gap-2">
+	<kol-accordion _label="Element 1">
+		<div>
+			Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+			voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+			voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+		</div>
+	</kol-accordion>
+	<kol-accordion _label="Element 2">
+		<div>
+			Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+			voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+			Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+			voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+		</div>
+	</kol-accordion>
+</div>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|------------------------|-------|
+| `click` | Element is clicked | - |
+
+### Example
+
+<div class="grid gap-2">
+	<kol-accordion _label="Element 1">
+		<div>
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+		</div>
+	</kol-accordion>
+	<kol-accordion _label="Element 2">
+		<div>
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+		</div>
+	</kol-accordion>
+</div>
+
+## Usage
+
+### Heading in the Accordion tab
+
+The text to be displayed as a heading in the Accordion tab is passed through the **`_label`** attribute. In addition to special characters, the text can also contain umlauts or spaces.
+
+### Heading level
+
+The heading level is passed through the **`_level`** attribute. Levels **1** to **6** are possible
+
+### Contents of the Accordion
+
+The main content of the accordion is transferred via the slot.
+
+**`<kol-accordion _label="Element 1">Accordion content</kol-accordion>`**
+
+### Show Accordion open
+
+By default, the Accordion will appear closed after the page loads. If you want the accordion to be displayed open, use the **\_open** attribute additionally.
+
+### Advantages
+
+1. **Space saving**: Ideal for content that would otherwise take up a lot of space.
+2. **Improved user experience**: Users can collapse and expand content in a targeted manner.
+3. **Structure and overview**: Content is structured logically and appears less overwhelming.
+
+### Best practices
+
+1. **Appropriate use**
+Use accordions to group content under a thematic umbrella, especially for long sections of text or detailed information.
+
+2. **Supporting Information**
+Place additional or less important information in accordions that doesn't necessarily have to be immediately visible.
+
+3. **Reduction of side length**
+Use Accordions to reduce the visual length of a webpage without limiting content accessibility.
+
+4. **Clear and descriptive headings**
+Use concise and meaningful headings that clearly describe the content of each section to make it easier to navigate.
+
+5. **Keep important actions and content visible**
+Avoid hiding critical call-to-action elements or key information within an accordion.
+
+6. **Ensure visibility of error messages**
+Always place error messages outside of an accordion to avoid missing important information.
+
+7. **Do not use as a selection element**
+Do not use accordions as interactive selectors or filter elements as they are not intuitive for such interactions.
+
+8. **Place important legal information outside**
+Ads such as privacy or legal notices should not be hidden in accordions as they must always be easily accessible and visible.
+
+9. **Maximum readability**
+Keep the content within an accordion short and clear. Use lists, paragraphs, or visual separations to avoid overwhelming.
+
+10. **Make important content visible by default**
+Consider whether it makes sense to leave one or more Accordion sections open by default, especially if this content is needed often.
+
+11. **Consider performance**
+Make sure the Accordion doesn't cause loading time issues, especially with dynamically loaded content. Content should be loaded as asynchronously and efficiently as possible.
+
+### Use cases
+
+- Frequently Asked Questions (FAQ)
+- Representation of details, properties or variants of an element
+- Groupings of
+- Forms with many options
+- Data in dashboards
+- Filter functions
+- Display menus on small screens where space is limited
+- Structured into settings pages
+- Splitting long articles or documentation into logical sections
+- Dynamic loading of content, which is only loaded when needed
+- Representation of a process or instructions in which individual steps are expanded
+
+## Accessibility
+
+In the **Accordion** component, the open/close icon is aligned to the left to enable better usability for users with limited field of vision.
+
+The use of icons such as `<` or `>` was deliberately avoided. The use of the `+` and `-` icons ensures better visibility and recognition of the open and closed status.
+
+When designing the color, particular emphasis was placed on achieving the highest possible contrast
+Default view placed.
+
+### Keyboard controls
+
+| button | Function |
+| ------- | ---------------------------------------------------- |
+| `Tab` | Jumps to the individual Accordion tabs.             |
+| `Enter` | Opens or closes the focused Accordion tab. |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#accordion" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="accordion" />
+
+## Live editor
+
+<LiveEditorCompact component="accordion" />
+
+## Examples
+
+### Simple accordions
+
+<Configurator component="accordion" sample="basic" />
+
+### Accordions with headings
+
+<Configurator component="accordion" sample="headlines" />
+
+### Accordions with header slot
+
+<Configurator component="accordion" sample="header" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/alert.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/alert.mdx
@@ -1,0 +1,160 @@
+---
+title: Alert
+description: Description, specification and examples for the Alert component.
+---
+import Readme from '/readmes/alert/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Alert
+
+Synonyms: Message
+
+The **Alert** component provides visual feedback to the users. It consists of a colored container, a heading, a content text and an icon. The icon used and the color design depend on the type `_type` of the alert.
+
+## Construction
+
+### Code
+
+```html
+<kol-alert _label="Überschrift im Alert" _level="1" _type="success">Textbereich im Alert</kol-alert>
+<kol-alert _label="Überschrift im Alert" _level="2" _type="info" _variant="card">Textbereich im Alert</kol-alert>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------------|-------|
+| `close` | Component is closing | - |
+
+### Example
+
+<kol-alert _label="Überschrift im Alert" _level="1" _type="success" >Textbereich im Alert</kol-alert>
+<kol-alert _label="Überschrift im Alert" _level="2" _type="info" _variant="card">Textbereich im Alert</kol-alert>
+
+## Usage
+
+### Headline
+
+The **Heading** of the Alert component is determined via the `_label` attribute.
+
+### Heading level
+
+The heading level is passed through the **`_level`** attribute. Levels **1** to **6** are possible
+
+### Type of alert
+
+The **Alert** component offers **four** different types, each of which relates to the color design and the icon used in the alert. You can choose from:
+
+<ul>
+	<li>Success</li>
+	<li>Error</li>
+	<li>Info</li>
+	<li>Warning</li>
+</ul>
+
+The type of an alert is specified using the `_type` attribute.
+
+### Contents of the alert
+
+The content of the alert is written between the opening element `<kol-alert>` and the closing `</kol-alert>`. The content can consist of any **HTML code**, but also of other **KoliBri** components.
+
+### Variant of the alert
+
+The **`_variant`** attribute can be used to specify the display variant in which the alert is displayed. `msg` makes the left, colored column with the icon extend over the entire height of the alert, `card` only sets the left column next to the heading.
+
+### Best practices
+
+- Use the **Alert** component in appropriate locations on your website to present information in the correct context.
+- Always use the correct **Type** of the **Alert** component to generate the desired reaction from users. For example, avoid the **_Error_** type if you want to indicate the successful completion of a save process.
+- Avoid placing too many **Alert** components on one page, as the information content is then often no longer perceived as particularly important by users.
+
+### Use cases
+
+- Use the **Alert** component if you want to alert users to errors when entering forms.
+- Use the **Alert** component to notify users of the successful execution of functions, e.g. **`Your request has been successfully saved`**.
+- Use the **Alert** component to provide users with further information on a topic.
+
+## Accessibility
+
+The **Alert** component has been optimized to display with the highest possible contrast.
+
+The additional icon (depending on the type selected) ensures that the user does not have to classify the information based on color alone.
+
+When using a screen reader, the icon is always read.
+The title should therefore not start with the **Alert** type, as this will result in the **Alert** type being read twice.
+
+**Example:**
+Correct: Label = "Fill in the field." → Output: "Error - fill in the field."
+Incorrect: Label = "Error: Fill in the field." → "Output: Error - Error: Fill in the field."
+
+The following accessibility points were particularly considered in the **Alert** component:
+
+- Font color is either white or black.
+- The font color depends on the background color and always changes to the font color with the greater color contrast to the background color.
+- If the color contrast is not sufficient for AA, the background color will be overwritten.
+
+### Accessible notifications with `_alert`
+
+The **Alert** component provides the ability to enable screen reader notifications via the `_alert` attribute. If `_alert` is set, the ARIA role `alert` or `aria-live="assertive"` is used to have screen readers automatically read the notification.
+
+**Important note on behavior:**
+The `_alert` attribute only works if:
+- The **Alert** component is initially re-rendered, or
+- The **content** of the alert changes
+
+Without a change in content, screen readers will not recognize new information and will not read the alert.
+
+**Examples of effective use:**
+```html
+<!-- Alert wird neu hinzugefügt (initial rendering) -->
+<kol-alert _label="Erfolgreich gespeichert" _type="success" _alert>
+  Ihre Daten wurden erfolgreich übertragen.
+</kol-alert>
+
+<!-- Inhalt ändert sich dynamisch -->
+<kol-alert _label="Status-Update" _type="info" _alert>
+  {dynamicMessage}
+</kol-alert>
+```
+
+**Not effective:**
+```html
+<!-- Alert bereits vorhanden, kein Re-Render, keine Inhaltsänderung -->
+<kol-alert _label="Statische Meldung" _type="info" _alert>
+  Diese Meldung wird nicht vorgelesen.
+</kol-alert>
+```
+
+### Note on `_alert` and screen readers
+
+With `<kol-alert>`, `role="alert"` and `aria-live="polite"` cannot be set into effect later; Both behave the same and are only triggered in the screen reader when the content changes.
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#alert" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="alert" />
+
+## Live editor
+
+<LiveEditorCompact component="alert" />
+
+## Examples
+
+### Simply reports
+
+<Configurator component="alert" sample="basic" />
+
+### Card or as Msg
+
+<Configurator component="alert" sample="card-msg" />
+
+### With HTML structure
+
+<Configurator component="alert" sample="html" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/avatar.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/avatar.mdx
@@ -1,0 +1,62 @@
+---
+title: Avatar
+description: Description, specification and examples for the Avatar component.
+---
+
+import Readme from '/readmes/avatar/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Avatar
+
+Synonyms: Persona
+
+The **Avatar** component displays either a small image of the user or their initials if no image is available.
+
+## Construction
+
+### Code
+
+```html
+<kol-avatar _label="Erika Maria Mustermann"></kol-avatar>
+<kol-avatar _label="Erika"></kol-avatar>
+<kol-avatar _src="https://www.w3schools.com/howto/img_avatar.png" _label="Erika Maria Mustermann"></kol-avatar>
+```
+
+### Examples
+
+<kol-avatar _label="Erika Maria Mustermann"></kol-avatar>
+<kol-avatar _label="Erika"></kol-avatar>
+<kol-avatar _src="https://www.w3schools.com/howto/img_avatar.png" _label="Erika Maria Mustermann"></kol-avatar>
+
+## Usage
+
+### With picture
+
+In the default view, the **Avatar** component displays an avatar image. To do this, the `_src` attribute must be specified with a URL to the image.
+Additionally, it is necessary to specify the `_label` attribute with the user's name so that alternative text can be marked.
+
+### Without picture
+
+The **Avatar** component can also be used without the `_src` attribute and in this case will show the user's initials based on the
+`_label` attribute.
+
+### Use cases
+
+Use the **Avatar** component to display a user's image.
+
+## Accessibility
+
+For the **Avatar** component, the following accessibility points were particularly considered:
+
+- The component is labeled as an aria label with a description text that includes the user's name.
+- The initials shown as an alternative to the avatar image are considered a purely visual, semantically irrelevant element and for screen readers
+hidden accordingly.
+
+<Readme />
+
+<ExampleLink component="avatar" />
+
+## Live editor
+
+<LiveEditorCompact component="avatar" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/badge.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/badge.mdx
@@ -1,0 +1,133 @@
+---
+title: Badge
+description: Description, specification and examples for the Badge component.
+---
+
+import Readme from '/readmes/badge/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Badge
+
+With **Badges** you can visually highlight certain information on your website.
+In addition to specifying the background color and automatically calculating the text color, KoliBri also offers the option of giving a badge an icon and/or a different font style.
+
+## Construction
+
+### Code
+
+```html
+<kol-badge _label="Beispieltext auf hellem Hintergrund mit dunkler Schriftfarbe" _color="#b7e4b4" _icons="codicon codicon-home"></kol-badge>
+<kol-badge _label="Beispieltext auf dunklem Hintergrund mit heller Schriftfarbe" _color="#0c8703" _icons="codicon codicon-home"></kol-badge>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------------|----------------------------------------------------------------------------------------------------------------|-------|
+| `click` | Smart button is clicked | - |
+| `onMouseDown` | A button on a pointing device is pressed while the pointer is inside the Smart Button | - |
+
+### Example
+
+<kol-badge _label="Beispieltext auf hellem Hintergrund mit dunkler Schriftfarbe" _color="#b7e4b4" _icons="codicon codicon-home"></kol-badge>
+<kol-badge _label="Beispieltext auf dunklem Hintergrund mit heller Schriftfarbe" _color="#0c8703" _icons="codicon codicon-home"></kol-badge>
+
+## Context for badges
+
+To improve usability and accessibility, badges should
+always be used in the context of a meaningful headline.
+
+Make sure each group of badges is accompanied by a heading that describes the shared context or theme. Avoid presenting badges without such descriptive headings.
+
+### Example
+
+```html
+<kol-heading _label="Beispielüberschrift" _level="2"></kol-heading>
+<div>
+	<kol-badge _label="Beispieltext auf hellem Hintergrund mit dunkler Schriftfarbe" _color="#b7e4b4" _icons="codicon codicon-home"></kol-badge>
+	<kol-badge _label="Beispieltext auf dunklem Hintergrund mit heller Schriftfarbe" _color="#0c8703" _icons="codicon codicon-home"></kol-badge>
+</div>
+```
+
+## Usage
+
+### Label in the badge
+
+The text to be displayed in the badge is passed via the **\_label** attribute. In addition to special characters, the text can also contain umlauts or spaces.
+The element `<kol-badge></kol-badge>` does not contain any text itself.
+
+### Badge background color
+
+By default, a badge without any further information about the background color is displayed with a light gray font color on a black background. Other background colors can be selected using the **\_color** attribute.
+
+The desired background color is specified in hexadecimal notation, e.g. **\_color="#000000"** for black.
+
+The text color is automatically calculated as a contrast color to the selected background color.
+
+### Icons
+
+An icon (**`_icon`**) can be specified either as a string or as an object.
+Pass the icon class as a string (e.g.: `_icons="codicon codicon-home`); the icon is displayed to the left of the text.
+The object is of type `KoliBriAllIcon`, so it can have one or more of the keys `top`, `right`, `bottom` and `left`. These are then either a string (see above) or an object of type `KoliBriCustomIcon`, which consists of `icon` (string, see above) and `style` (optional, style object).
+
+<kol-link _href="https://microsoft.github.io/vscode-codicons/dist/codicon.html" _target="_blank" _label="Übersicht Codicons"></kol-link>
+
+### Font style
+
+The font style is adopted by the host and can therefore be set externally via CSS.
+
+### Best practices
+
+- Use badges to display important information close to each item.
+- Use badges to draw attention to changed values ​​or status.
+- A badge informs the user that something has been newly created or updated, e.g. E.g. an “unread report” or an activity notification.
+- Always maintain the same position of the badge in the same use cases to ensure a consistent appearance.
+
+## Use cases
+
+### Use badge as bullet point
+
+<ul class="m-0 p-0">
+	<li class="flex gap-2">
+		<kol-badge _label="1" _color="#0747a6"></kol-badge>
+		<kol-heading _level="2" _label="Auswahl Anliegen"></kol-heading>
+	</li>
+	<li class="flex gap-2">
+		<kol-badge _label="2" _color="#0747a6"></kol-badge>
+		<kol-heading _level="2" _label="Auswahl Amtsstelle"></kol-heading>
+	</li>
+	<li class="flex gap-2">
+		<kol-badge _label="3" _color="#0747a6"></kol-badge>
+		<kol-heading _level="2" _label="Terminauswahl"></kol-heading>
+	</li>
+</ul>
+
+## Accessibility
+
+To comply with accessibility rules, an optimal contrast between the background color and text color of the badge is essential. KoliBri therefore offers an automatic calculation of the text color from the selected background color. The text colors **black** and **white** are possible and are output depending on the background color.
+
+The additional output of an **icon** ensures that the user can also record the type of information.
+
+<kol-alert _type="info">Eine explizite Angabe der Textfarbe ist nicht möglich.</kol-alert>
+
+<Readme />
+
+<ExampleLink component="badge" />
+
+## Live editor
+
+<LiveEditorCompact component="badge" />
+
+## Examples
+
+### Simple badges
+
+<Configurator component="badge" sample="basic" />
+
+### Badges with switches
+
+<Configurator component="badge" sample="button" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/breadcrumb.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/breadcrumb.mdx
@@ -1,0 +1,106 @@
+---
+title: Breadcrumb
+description: Description, specification and examples for the Breadcrumb component.
+---
+
+import Readme from '/readmes/breadcrumb/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Breadcrumb
+
+With the help of the **Breadcrumb** component, the path to the current position of a web page can be displayed in a hierarchical structure.
+
+## How it works
+
+The **Breadcrumb** component displays the current position of a web page in a horizontal navigation structure. The last element on the right represents the current page itself.
+This is not provided with a link. All elements to the left of the current page have a link to the linked page.
+
+## Construction
+
+### Code
+
+```html
+<div>
+	<kol-breadcrumb _links='[{"_label":"Startseite","_href":"#/"},{"_label":"Unterseite von Startseite","_href":"#/unterseite"}]'></kol-breadcrumb>
+</div>
+```
+
+### Example
+
+<kol-breadcrumb _links='[{"_label":"Startseite","_href":"#/"},{"_label":"Unterseite von Startseite","_href":"#/unterseite"}]'></kol-breadcrumb>
+
+## Usage
+
+### Definition of links
+
+The **\_links** attribute expects a JSON object to be passed, from which the structure of the breadcrumb paths to be displayed results. The JSON object passes any number of elements, each providing a number of properties and values.
+
+Each property and its associated value must be enclosed in double quotes.
+
+Individual elements are written in curly brackets and separated by **commas**.
+
+The entire JSON object must be passed to the **`_links`** attribute in square brackets.
+
+<b>Folgende Eigenschaften stehen zur Verfügung:</b>
+
+- **`_href`** passes the link to be used for this element.
+- **`_icon`** (optional) passes the name of the icon if an icon should be displayed in addition to the text of the element. The <kol-link _href="https://microsoft.github.io/vscode-codicons/dist/codicon.html" _target="_blank" _label="Codicons"></kol-link> are available
+- **`_hide-label`** (optional). If the value is set to **true**, only the icon appears in the link, without any other text. The `_icon` property must be set.
+- **`_label`** passes the text to be displayed for this element.
+
+Example of a JSON object passed to the **`_links`** attribute:
+
+```JSON
+[
+  { '_label': 'Startseite', '_href': '#/', '_icons': 'codicon codicon-home', '_hide-label': true },
+  { '_label': '1. Unterseite', '_href': '/unterseite_eins' },
+  { '_label': '2. Unterseite', '_href': '/unterseite_zwei' }
+]
+```
+
+<kol-breadcrumb _links='[{"_label":"Startseite","_href":"#/","_icons":"codicon codicon-home","hide-label": "true"},{"_label":"1. Unterseite","_href":"#/1_unterseite"},{"_label":"2. Unterseite","_href":"#/2_unterseite"}]'></kol-breadcrumb>
+
+### Best practices
+
+- The **Breadcrumb** component is an important element for effective search engine optimization of your website.
+- Breadcrumb navigation also provides additional overview for users of the website.
+- Position the breadcrumb as high as possible on your content pages to ensure that search engines can use it as an additional source of information about the structure of your website.
+- Position the breadcrumb component on each content page of your website. This ensures that visitors can find their way around at any time and recognize their current position.
+- Avoid placing breadcrumb navigation on the homepage.
+- Only use breadcrumb navigation if it offers real added value for users.
+- Breadcrumb navigation may not make sense on mobile versions of a website.
+
+### Use cases
+
+Breadcrumb navigation can be found on a large majority of current websites. The classic application case therefore describes the general installation of this component.
+
+## Accessibility
+
+For optimal accessibility, make sure to label the `_label` attribute correctly. Please pay particular attention to this note if you use the `_hide-label` option and would therefore forego descriptive text in the link.
+
+Note that the last element in the breadcrumb component can also be accessed using the Tab key, even though there is no link there. This means that this element can also be accessed and read out by the screen reader.
+
+### Keyboard controls
+
+| button | Function |
+| ------- | ---------------------------------------------------------------- |
+| `Tab` | Jumps to the individual elements of the breadcrumb navigation. |
+| `Enter` | Opens the link of the current item.                      |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#breadcrumb" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="breadcrumb" />
+
+## Live editor
+
+<LiveEditorCompact component="breadcrumb" />
+
+## Examples
+
+<Configurator component="breadcrumb" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/button-link.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/button-link.mdx
@@ -1,0 +1,59 @@
+---
+title: ButtonLink
+description: Description, specification and examples for the ButtonLink component.
+---
+
+import Readme from '/readmes/button-link/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# ButtonLink
+
+The ButtonLink is semantically a button and has the design of a link. For this purpose, all relevant properties of the button component are adopted and expanded to include the design-determining properties of the link.
+
+A button can be deactivated and therefore a ButtonLink has the property `_disabled`. The UX designer decides how this will be visually designed.
+
+Instead of using `_href` like with a link, with a ButtonLink the property is controlled via the `click callback`. The `_on` property is used for this.
+
+A link has the property `target`, which may open the link in a new window/tab. The behavior has not yet been implemented.
+
+Since the link, unlike the button, is offered in several variants (primary or secondary, etc.), the properties `_customClass` and `_variant` are not available.
+
+## Construction
+
+### Code
+
+```html
+<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------------|-----------------------------------------------------------------------------------------------------|-------------------|
+| `click` | Element is clicked | `_value` property |
+| `onMouseDown` | A pointing device key is pressed while the pointer is inside the element | - |
+
+### Example
+
+<div class="flex gap-2">
+	<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
+</div>
+
+<Readme />
+
+<ExampleLink component="button-link" />
+
+## Live editor
+
+<LiveEditorCompact component="button-link" />
+
+## Examples
+
+<Configurator component="button-link" sample="basic" />
+<Configurator component="button-link" sample="icons" />
+<Configurator component="button-link" sample="image" />
+<Configurator component="button-link" sample="target" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/button.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/button.mdx
@@ -1,0 +1,139 @@
+---
+title: Button
+description: Description, specification and examples for the Button component.
+---
+
+import Readme from '/readmes/button/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Button
+
+**Buttons** are used to show users choices for actions and to arrange them in a clear hierarchy. They help users find the most important actions on a page or within a viewport and enable them to carry out these actions. The button label is used to clearly show users which action is triggered. Buttons allow users to confirm a change, complete steps in a task, or make decisions.
+
+## Construction
+
+### Code
+
+```html
+<kol-button _label="Primary" _variant="primary"></kol-button>
+<kol-button _label="Secondary" _variant="secondary"></kol-button>
+<kol-button _label="Normal" _variant="normal"></kol-button>
+<kol-button _label="Danger" _variant="danger"></kol-button>
+<kol-button _label="Ghost" _variant="ghost"></kol-button>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | Value |
+|---------------|:-----------------:|
+| `onClick` | `_value` property |
+| `onMouseDown` | - |
+
+### Example
+
+default
+
+<div class="flex flex-wrap gap-2">
+	<kol-button _label="Primary" _variant="primary"></kol-button>
+	<kol-button _label="Secondary" _variant="secondary"></kol-button>
+	<kol-button _label="Normal" _variant="normal"></kol-button>
+	<kol-button _label="Danger" _variant="danger"></kol-button>
+	<kol-button _label="Ghost" _variant="ghost"></kol-button>
+</div>
+
+Disabled
+
+<div class="flex flex-wrap gap-2">
+	<kol-button _label="Primary" _variant="primary" _disabled></kol-button>
+	<kol-button _label="Secondary" _variant="secondary" _disabled></kol-button>
+	<kol-button _label="Normal" _variant="normal" _disabled></kol-button>
+	<kol-button _label="Danger" _variant="danger" _disabled></kol-button>
+	<kol-button _label="Ghost" _variant="ghost" _disabled></kol-button>
+</div>
+
+## Usage
+
+### Caption
+
+To clearly label the button, use the **`_label`** attribute.
+`_label="Button label"`
+
+### Icons
+
+Icons (**`_icons`**) can be specified either as a string or as an object.
+Pass the icon class as a string (e.g.: `_icons="codicon codicon-home`); the icon is displayed to the left of the text.
+The object is of type `KoliBriAllIcon`, so it can have one or more of the keys `top`, `right`, `bottom` and `left`. These are then either a string (see above) or an object of type `KoliBriCustomIcon`, which consists of `icon` (string, see above) and `style` (optional, style object).
+
+<kol-link _href="https://microsoft.github.io/vscode-codicons/dist/codicon.html" _target="_blank" _label="Übersicht Codicons"></kol-link>
+
+### Button without text
+
+Using **`_hide-label`** the button will only show the icon (<kol-link _href="#icon" _label="see icon"></kol-link>)
+
+<kol-alert _type="info">Beachten Sie, dass das Attribut **`_label`** auch dann gesetzt werden muss, wenn nur ein Icon angezeigt werden soll, dieses wird von Screenreadern vorgelesen und in den Tooltip gesetzt.</kol-alert>
+
+### Specify representation
+
+To control the display, use the **`_variant`** attribute. The default value is `primary`, alternatively `primary`, `secondary`, `normal`, `danger`, `ghost`, or `custom` can also be set.<br/>
+
+You can choose your own display by using the value `custom`. In this case, it is mandatory to set the **`_custom-class`** attribute so that the button can be selected in the shadow dome using CSS.
+
+### Best practices
+
+- Use a primary button for the next best action. Remaining calls to action should be presented as a secondary button.
+- Use buttons in consistent locations in the interface to improve user experience.
+- Use only one primary button per viewport. A button style can appear any number of times throughout the page.
+- The button label must describe the action the button performs. It should contain a verb (e.g. save). Use concise, specific, self-explanatory labels.
+- Button labels should always include a noun when there is room for interpretation about what the verb is responsible for. Do not use generic terms such as "OK", especially in the event of an error. Mistakes are never “OK”.
+- Do not use multiple buttons in the “primary” style within a grouping.
+- Do not use buttons as a link or as a navigation element.
+
+## Accessibility
+
+For people with a limited field of vision, positioning the **icon** in the button to the left of the label is optimal.
+
+Problems with Disabled status
+
+- Display contrasts
+- Possibility of user feedback
+
+### Keyboard controls
+
+| button | Function |
+| ------- | ---------------------------------------------------------------- |
+| `Tab` | Jumps to the individual button and focuses on it.          |
+| `Enter` | Executes the focused button's onClick method. |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#button" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="button" />
+
+## Live editor
+
+<LiveEditorCompact component="button" />
+
+## Examples
+
+### Buttons
+
+<Configurator component="button" sample="basic" />
+
+### Icon buttons
+
+<Configurator component="button" sample="icon-only" />
+
+### Button with icons
+
+<Configurator component="button" sample="icons" />
+
+### Buttons with uniform width
+
+<Configurator component="button" sample="width" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/card.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/card.mdx
@@ -1,0 +1,109 @@
+---
+title: Card
+description: Description, specification and examples for the Card component.
+---
+
+import Readme from '/readmes/card/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Card
+
+The **Card** component is ideal for visually highlighting individual areas of your website. With their help you can structure your content very easily.
+
+The **Card** component consists of a **_Title area_**, a **_Content area_**.
+
+The **title area** is displayed in a larger font. The **content area** is visually separated by a horizontal dividing line below the title area and is output in the standard font.
+
+## Construction
+
+### Code
+
+```html
+<kol-card _label="Testtitel">
+	<div>
+		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+		At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+		dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+		et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+	</div>
+</kol-card>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------------|-------|
+| `close` | Component is closing | - |
+
+### Example
+
+<kol-card _label="Testtitel">
+	<div>
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.
+At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem Ipsum
+dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+	</div>
+</kol-card>
+
+## Usage
+
+### Simple standard card
+
+In the standard view, a **Card** consists of a title area and an empty content area.
+KoliBri automatically sets the horizontal dividing line between the two areas.
+
+### Title of the Card component
+
+You determine the title of the card by setting the **`_label`** attribute. Here you can enter any text, including special characters and umlauts.
+Note that **HTML code** is not allowed. If not set, three dots are shown.
+The heading level of the title is passed through the **`_level`** attribute. Levels **1** to **6** are possible
+
+### Content containers
+
+You determine the contents in the content area of ​​the card by inserting a **content container** within the `<kol-card></kol-card> element`. You can insert any **HTML code** here.
+
+Please note that while you can use any HTML tag as a content container, it is recommended to use a `<div></div>` tag.
+
+```html
+<kol-card _label="Beispiel" _level="1">
+	<div>Text im Inhalts-Bereich</div>
+</kol-card>
+```
+
+### Best practices
+
+- Use the **Card** component to visually encapsulate self-contained subject areas.
+- Use the **Card** component to semantically structure your content.
+- Avoid using too many cards on a content page.
+- Avoid placing important content within the Card component if the associated action elements (buttons, links, etc.) are not within the same Card.
+
+<Readme />
+
+<ExampleLink component="card" />
+
+## Live editor
+
+<LiveEditorCompact component="card" />
+
+## Examples
+
+###Card
+
+<Configurator component="card" sample="basic" />
+
+### Confirmation card
+
+<Configurator component="card" sample="confirm" />
+
+### Cards in the grid flow
+
+<Configurator component="card" sample="flex" />
+
+### Card as an item list
+
+<Configurator component="card" sample="selection" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/combobox.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/combobox.mdx
@@ -1,0 +1,70 @@
+---
+title: Combobox
+description: Description and specification for the Combobox component.
+---
+
+import Readme from '/readmes/combobox/readme.md';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Combobox
+
+Synonyms: Autocomplete, Select, Dropdown
+
+The **Combobox** component creates a selection list that combines an input field with a list of selectable options displayed below.
+
+## Construction
+
+### Code
+
+```html
+<kol-combobox _suggestions="['Herr','Frau','Firma']" _label="Anrede" _value="Herr"></kol-combobox>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-combobox  _suggestions="['Herr','Frau','Firma']" _label="Anrede" _value="Herr"></kol-combobox>
+
+## Usage
+
+The choices are passed to the component as a JSON array via the **`_suggestions`** attribute.
+
+Example of constructing the JSON array:
+
+```json
+["Herr", "Frau", "Firma"]
+```
+
+<!--### Best practices-->
+
+<!-- ## Barrierefreiheit -->
+
+### Keyboard controls
+
+| button | Function |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the selection field.                                                                                                                                                                         |
+| `Enter` | If the listbox is open and an option is focused, this function selects the focused option and closes the listbox. If no option is focused, it just opens the listbox. |
+| `ArrowDown` | Opens the listbox when it is closed and moves the visual focus down one option when the listbox is open.                                                              |
+| `ArrowUp` | Opens the listbox when it is closed and moves the visual focus up one option when the listbox is open.                                                               |
+| `Escape (Esc)` | Closes the listbox and removes visual focus from the combobox without making a selection.                                                                                                |
+| `Home` | Moves visual focus to the first option in the listbox.                                                                                                                                     |
+| `End` | Moves the visual focus to the last option in the listbox.                                                                                                                                    |
+| `PageUp(PageUp)` | Jumps ten options up in the list box and focuses on the corresponding option.                                                                                                             |
+| `PageDown(PageDown)` | Jumps ten options down in the list box and focuses on the corresponding option.                                                                                                            |
+| `Printable Characters` | Focuses on the first option that begins with the pressed character.                                                                                                                                |
+
+<Readme />
+
+<ExampleLink component="combobox" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/details.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/details.mdx
@@ -1,0 +1,111 @@
+---
+title: Details
+description: Description, specification and examples for the Details component.
+---
+
+import Readme from '/readmes/details/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Details
+
+Synonyms: Disclosure, Collapse, Summary Detail
+
+With the help of the **Detail** component, further information can initially be displayed with a short introductory text, which is only available after clicking
+can be expanded by the user to a full-size arrow icon.
+
+By default, the **Detail** component appears as a single-line layout element consisting of an arrow icon and a subsequent,
+short introductory text is formed. The actual content of the component is only opened downwards after clicking on the header area. The arrow icon changes
+its orientation from **_right_** to **_bottom_**.
+In the same way, the component can also be closed again and the contents can be hidden.
+
+## Construction
+
+### Code
+
+```html
+<kol-details _label="Nach Laden der Seite geschlossen">
+	Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At
+	vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+	amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+</kol-details>
+```
+
+### Example
+
+<kol-details _label="Nach Laden der Seite geschlossen">
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+</kol-details>
+
+## Usage
+
+### Show Open
+
+Use the **`_open`** attribute to represent the component open.
+
+### Introductory text
+
+Use the **`_label`** attribute to define the text to display as a heading.
+
+### Best practices
+
+- Use the **Detail** component to arrange supplementary content on a main topic to save space.
+- The **Detail** component is well suited for realizing an FAQ page, where the question can be output via the **`_label`** attribute and the answer in the content area.
+- Avoid displaying important information, such as legal aspects, in a hidden area. There is no guarantee that the user will read this information safely.
+- Avoid using too many **Detail** components, as the clarity of the page may suffer.
+
+### Use cases
+
+#### Details component within a body of text
+
+<div>
+	<p>
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+	</p>
+	<kol-details _label="Erst nach Klick offen">
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+	</kol-details>
+	<p>
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita
+kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+	</p>
+</div>
+
+## Accessibility
+
+- The **Details** component is ideal for implementing context-sensitive help for accessibility.
+
+### Keyboard controls
+
+| button | Function |
+| ------- | ----------------------------------------------- |
+| `Tab` | Focuses the Details component.              |
+| `Enter` | Opens or closes the contents of the component. |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-context-help.html" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="details" />
+
+## Live editor
+
+<LiveEditorCompact component="details" />
+
+## Examples
+
+<Configurator component="details" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/drawer.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/drawer.mdx
@@ -1,0 +1,135 @@
+---
+title: Drawer
+description: Description, specification and examples for the Drawer component.
+---
+
+import Readme from '/readmes/drawer/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+Synonyms: Corner Dialog, Prompt
+Using the **Drawer** component, additional information or navigation elements can be displayed in a fold-out side window. An open drawer can be closed via ESC.
+
+The **Drawer** component is hidden by default. It is usually only displayed after clicking on a button or other trigger or controlled with the `_open` attribute.
+
+```html
+<kol-drawer _label="Drawer" _open  _align="top"></kol-drawer>
+```
+
+### Example
+
+#### Uncontrolled
+
+In _Uncontrolled_ mode, the drawer is controlled via the `open()` and `close()` methods.
+
+```html
+<kol-drawer id="example-drawer" _align="left" _label="Drawer">
+	<div>
+		<p>Dies ist der Inhalt des Drawers. Hier können Sie beliebige HTML-Elemente einfügen.</p>
+		<kol-button class="close-drawer" _label="Schließen"></kol-button>
+	</div>
+</kol-drawer>
+<kol-button id="drawer-open-button" _label="Drawer öffnen"></kol-button>
+
+<script>
+	const drawer = document.querySelector('#example-drawer');
+	const drawerOpenButton = document.querySelector('#drawer-open-button');
+
+	function openDrawer() {
+		drawer.open();
+	}
+
+	function closeDrawer() {
+		drawer.close();
+	}
+
+	document.querySelectorAll('.close-drawer').forEach((b) => (b.onclick = closeDrawer));
+	drawerOpenButton.onclick = openDrawer;
+</script>
+```
+
+#### Controlled
+
+In _Controlled_ mode, the drawer is controlled via the `_open` attribute.
+
+```html
+<kol-drawer _open="true" _align="left" _label="Drawer">
+	<p>Drawer Inhalt</p>
+</kol-drawer>
+```
+
+## Usage
+
+To open and close the **Drawer** programmatically, use the **`open()`** and **`close()`** methods. Make sure the **`_label`** attribute is set to ensure accessibility. You can adjust the drawer's alignment using the **`_align`** attribute and the **left**, **top**, **right** or **bottom** values ​​to display it on the desired side of the screen. Use the **`_on`** attribute to perform custom actions when closing the drawer. An open **Drawer** can be closed via **ESC**.
+
+## Accessibility
+
+The `_label` attribute provides a clear and understandable label for the drawer. This improves usability for people using screen readers, as the label acts as an **`aria-label`**, thus explaining the meaning and function of the drawer.
+
+### Drawer
+
+When the **Drawer** is opened, the focus is automatically set to the contents of the drawer. This ensures that screen reader users immediately know that a new area has opened and can interact directly. When the drawer is closed, the focus returns to the previous active element, providing a seamless user experience.
+
+The **Drawer** component supports full keyboard navigation. Users can use the Tab key to navigate through the interactive elements within the drawer. In addition, the **Drawer** can be closed quickly and easily with the ESC key, which makes it easier to use.
+
+While the **Drawer** is open, all selectable elements outside the drawer are deactivated. This prevents unwanted interactions with the background content and draws users' attention to the **Drawer** content.
+
+### Keyboard controls
+
+| button | Function |
+| ----------- | ------------------------------------------------------------------------------------------------ |
+| `Tab` | When the drawer is open, all focusable elements are accessed in order. |
+| `ESC key` | Closes the drawer.                                                                         |
+
+## Animations
+
+Optionally, animations with keyframes can be added. It is important that the keyframes contain the names `slideIn` or `slideOut` and are defined on the `drawer__wrapper` class.
+
+**Example:**
+
+```scss
+.drawer__wrapper {
+	&--left {
+		animation: slideInLeft $duration forwards;
+		&.is-closing {
+			animation: slideOutLeft $duration forwards !important;
+		}
+	}
+	&--right {
+		animation: slideInRight $duration forwards;
+		&.is-closing {
+			animation: slideOutRight $duration forwards;
+		}
+	}
+	&--top {
+		animation: slideInTop $duration forwards;
+		&.is-closing {
+			animation: slideOutTop $duration forwards;
+		}
+	}
+	&--bottom {
+		animation: slideInBottom $duration forwards;
+		&.is-closing {
+			animation: slideOutBottom $duration forwards;
+		}
+	}
+}
+```
+
+## Links and references
+
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="drawer" />
+
+## Live editor
+
+<LiveEditorCompact component="drawer" />
+
+## Examples
+
+<Configurator component="drawer" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
@@ -1,0 +1,38 @@
+---
+title: Form
+description: Description, specification and examples for the Form component.
+---
+
+import Readme from '/readmes/form/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Form
+
+The **Form** component is used to enclose all input fields, to correctly position the information text for mandatory fields and to forward the `submit` and `reset` events.
+
+## Construction
+
+### Code
+
+```html
+<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
+	<kol-input-text _label="Vorname"></kol-input-text>
+	<kol-input-text _label="Nachname"></kol-input-text>
+</kol-form>
+```
+
+### Example
+
+<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
+	<kol-input-text _label="Vorname"></kol-input-text>
+	<kol-input-text _label="Nachname"></kol-input-text>
+</kol-form>
+
+<Readme />
+
+<ExampleLink component="form" />
+
+## Live editor
+
+<LiveEditorCompact component="form" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/heading.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/heading.mdx
@@ -1,0 +1,58 @@
+---
+title: Heading
+description: Description, specification and examples for the heading component.
+---
+
+import Readme from '/readmes/heading/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Heading
+
+The **Heading** component can be used anywhere a heading should be displayed. By using different sizes, content can be clearly structured and pages can be presented effectively and varied. It separates styling from semantics and allows for flexibility.
+
+## Construction
+
+### Code
+
+```html
+<kol-heading _level="1" _label="Inhalt einer H1-Überschrift"></kol-heading>
+<kol-heading _level="2" _label="Inhalt einer H2-Überschrift"></kol-heading>
+<kol-heading _level="3" _label="Inhalt einer H3-Überschrift"></kol-heading>
+<kol-heading _level="4" _label="Inhalt einer H4-Überschrift"></kol-heading>
+<kol-heading _level="5" _label="Inhalt einer H5-Überschrift"></kol-heading>
+<kol-heading _level="6" _label="Inhalt einer H6-Überschrift"></kol-heading>
+```
+
+### Example
+
+<kol-heading _level="1" _label="Inhalt einer H1-Überschrift"></kol-heading>
+<kol-heading _level="2" _label="Inhalt einer H2-Überschrift"></kol-heading>
+<kol-heading _level="3" _label="Inhalt einer H3-Überschrift"></kol-heading>
+<kol-heading _level="4" _label="Inhalt einer H4-Überschrift"></kol-heading>
+<kol-heading _level="5" _label="Inhalt einer H5-Überschrift"></kol-heading>
+<kol-heading _level="6" _label="Inhalt einer H6-Überschrift"></kol-heading>
+
+## Usage
+
+The heading level is passed through the **`_level`** attribute. Levels **1** to **6** are possible
+
+### Best practices
+
+- When using headings, pay attention to the recommended semantics for search engine optimization.
+- Use headings of different sizes to create a meaningful structure for your content.
+
+<Readme />
+
+<ExampleLink component="heading" />
+
+## Live editor
+
+<LiveEditorCompact component="heading" />
+
+## Examples
+
+<Configurator component="heading" sample="basic" />
+<Configurator component="heading" sample="paragraph" />
+<Configurator component="heading" sample="badged" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/icon.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/icon.mdx
@@ -1,0 +1,65 @@
+---
+title: Icon
+description: Description, specification and examples for the Icon component.
+---
+
+import Readme from '/readmes/icon/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Icon
+
+With the help of the **Icon** component, icons from integrated icon fonts can be displayed at any position. The output of the icon can be controlled using the **`_icon`** attribute and is made barrier-free using the **`_label`** attribute. By default the output is as an _`inline`_ element.
+
+Currently the icons are supported by <kol-link _href="https://microsoft.github.io/vscode-codicons/dist/codicon.html" _target="_blank" _label="Codicons"></kol-link>.
+
+<kol-alert _heading="Hinweis" _type="info">Es ist wichtig, dass in der Rahmenseite (`index.html`) die CSS-Dateie(n) der Icon-Font(s) eingebunden ist/sind.</kol-alert>
+
+## Construction
+
+The **Icon** component is created via the HTML tag `kol-icon`.
+
+### Code
+
+```html
+<kol-icon _label="Zu Hause" _icons="codicon codicon-home"></kol-icon>
+```
+
+### Example
+
+<kol-icon _label="Zu Hause" _icons="codicon codicon-home"></kol-icon>
+
+### Icons
+
+The property `_icons` expects a string with the class names of the icons to be shown (e.g.: `_icons="codicon codicon-home`).
+
+<kol-link _href="https://microsoft.github.io/vscode-codicons/dist/codicon.html" _target="_blank" _label="Übersicht Codicons"></kol-link>
+
+## Accessibility
+
+It is important for context-relevant graphics to be labeled.
+
+- <kol-link _href="https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/"></kol-link>
+
+### Labels
+
+A context-relevant icon must be labeled using the `_label` property.
+
+## Links and references
+
+- <kol-link _href="https://github.com/microsoft/vscode-codicons" _target="_blank" _label="Codicons"></kol-link>
+- <kol-link _href="https://fontawesome.com" _target="_blank" _label="Font-Awesome"></kol-link>
+- <kol-link _href="https://icofont.com" _target="_blank" _label="Icofont"></kol-link>
+
+<Readme />
+
+<ExampleLink component="icon" />
+
+## Live editor
+
+<LiveEditorCompact component="icon" />
+
+## Examples
+
+<Configurator component="icon" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/image.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/image.mdx
@@ -1,0 +1,68 @@
+---
+title: Image
+description: Description, specification and examples for the Image component.
+---
+
+import Readme from '/readmes/image/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Image
+
+Synonyms: Img, Thumbnail
+
+> <kol-badge _label="untested"></kol-badge> This new component is marked as untested because the full accessibility test is still pending. The full test of new components and functionalities can only take place after a completed release.
+
+The **Image** component is used to display images.
+
+## Construction
+
+The **Image** component is created using the HTML tag `<kol-image>`.
+
+### Code
+
+```html
+<kol-image _src="url-zum-bild.jpg" _alt="Beschreibung des Bildes"></kol-image>
+<kol-image _src="nur-dekoratives-bild.jpg" _alt=""></kol-image>
+<kol-image _src="hintergrundbild-der-hero-sektion.jpg" _alt="" _loading="eager"></kol-image>
+```
+
+### Examples
+
+<kol-image _src="https://placehold.co/100x100/cc006e/white" _alt="Beispielbild: 100 × 100"></kol-image>
+
+## Usage
+
+### Images in different resolutions and/or aspect ratios
+
+Using **`_srcset`** (and **`_sizes`**), different images can be stored for different resolutions and pixel densities (of the display) in order to deliver sharp images on large screens and not use up bandwidth unnecessarily on small monitors.
+Furthermore, different file formats can be specified using **`_srcset`** in order to save bandwidth for modern browsers, but still support older devices.
+Even when using **`_srcset`**, **`_src`** should be used, as this is used by browsers as the last option if a) **`srcset`** is not supported, or b) no suitable image was found there.
+<kol-link _href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset" _target="_blank" _label="MDN Artikel zu srcset"></kol-link>
+<kol-link _href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes" _target="_blank" _label="MDN Artikel zu sizes"></kol-link>
+For more information about **`_srcset`** see [Links and References](#links-and-references)
+
+### Loading behavior
+
+The **`_loading`** attribute is optional. Either `eager` or `lazy` can be set here, provided that `lazy` is used unset.
+`eager` ensures that the image is loaded as soon as you enter the page; with `lazy` the browser only loads the image shortly before it becomes visible. As a rule, `eager` does not have to be set, only set it if loading delays occur or the image is safely in the visible area when entering the page. (e.g.: logo in the header or hero)
+<kol-link _href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading" _target="_blank" _label="MDN Artikel zu loading"></kol-link>
+
+## Accessibility
+
+### Alternative text
+
+The **`_alt`** attribute is mandatory, but can be left blank (`_alt=""`) for purely decorative images.
+This description is read by screen readers and displayed by browsers if the image cannot/should not be loaded.
+
+## Links and references
+
+Detailed explanation of `_srcset` and `_sizes`: <kol-link _href="https://www.mediaevent.de/html/srcset.html" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="image" />
+
+## Live editor
+
+<LiveEditorCompact component="image" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/index.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/index.mdx
@@ -1,14 +1,12 @@
 ---
 title: Components
-description: On the following pages, you will find an overview of all the components available in KoliBri. The components are divided into different categories, which you can access via the menu on the left.
-tags:
-  - Examples
+description: On the following pages you will find an overview of all components available in KoliBri. The components are divided into different categories, which you can access via the menu on the left.
 ---
 
 import { ComponentList } from '@site/src/components/docs/ComponentList';
 
 # Components
 
-On the following pages, you will find an overview of all the components available in KoliBri. The components are divided into different categories, which you can access via the menu on the left.
+On the following pages you will find an overview of all components available in KoliBri. The components are divided into different categories, which you can access via the menu on the left.
 
 <ComponentList lang="en" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-checkbox.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-checkbox.mdx
@@ -1,0 +1,94 @@
+---
+title: InputCheckbox
+description: Description, specification and examples for the InputCheckbox component.
+---
+
+import Readme from '/readmes/input-checkbox/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputCheckbox
+
+The input type **_Checkbox_** generates a rectangular box that is activated and deactivated again by clicking on it. When activated, there is a colored tick in the box.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-checkbox _label="false">Ich stimme der <kol-link _href="#" _label="Datenschutzerklärung"></kol-link> zu.</kol-input-checkbox>
+<kol-input-checkbox _variant="switch" _label="Geburtsdatum anzeigen?"></kol-input-checkbox>
+<kol-input-checkbox _variant="button" _label="Schalter aktiviert" _checked></kol-input-checkbox>
+<kol-input-checkbox _variant="button" _label="Schalter deaktiviert"></kol-input-checkbox>
+```
+
+### Example
+
+<kol-input-checkbox _label="false">Ich stimme der <kol-link _href="#" _label="Datenschutzerklärung"></kol-link> zu.</kol-input-checkbox>
+<kol-input-checkbox _variant="switch" _label="Geburtsdatum anzeigen?"></kol-input-checkbox>
+<kol-input-checkbox _variant="button" _label="Schalter aktiviert" _checked></kol-input-checkbox>
+<kol-input-checkbox _variant="button" _label="Schalter deaktiviert"></kol-input-checkbox>
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|---------------------------------------------------------------------|----------------------------------------------------------------|
+| `focus` | Input field is focused | - |
+| `click` | Input field is clicked | - |
+| `input` | Checkbox is checked or unchecked (corresponds to native `input` event) | Defined `_value` if active, otherwise `null` |
+| `change` | Checkbox is checked or unchecked (corresponds to native `change` event) | Defined `_value` if active, otherwise `null` |
+| `blur` | Input field loses focus | - |
+
+## Usage
+
+Checkboxes are used as a single element or as a list of any number of checkboxes. They allow users to select one or more from a predefined number of options.
+
+### Variants
+
+Using the **`_variant`** attribute, the following variants can be selected (see examples above):
+
+- `button`: changes the icon depending on the status (example 3+4)
+- `switch`: turns the checkbox into a horizontal switch, where the right is considered active and the left is considered inactive. (Example 2)
+
+### Best practices
+
+- Use a single checkbox if you want a simple confirmation from users, e.g. accepting the data protection declaration.
+- Use a group of checkboxes to give users the opportunity to select one or more values.
+
+## Accessibility
+
+Avoid using many checkboxes on one page, as this will quickly make your content confusing and long. In such use cases, consider using a <kol-link _href="/docs/components/select" _label="/docs/components/select">Select box with **`_multiple`**</kol-link>.
+
+Make sure to assign a label to each checkbox, as this is read out by screen readers and thus enables the input field to be clearly identified.
+
+### Keyboard controls
+
+| button | Function |
+| ------ | ------------------------------------------------------------------------------------------------------------------ |
+| `Tab` | Focuses the checkbox or allows you to switch between checkboxes in a list.                               |
+| `Empty` | Activates or deactivates the checkbox. The **_Indeterminate_** state cannot be established via the keyboard. |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#checkbox" _target="_blank"></kol-link>
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-checkbox" />
+
+## Live editor
+
+<LiveEditorCompact component="input-checkbox" />
+
+## Examples
+
+<Configurator component="input-checkbox" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-color.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-color.mdx
@@ -1,0 +1,83 @@
+---
+title: InputColor
+description: Description, specification and examples for the InputColor component.
+---
+
+import Readme from '/readmes/input-color/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+#InputColor
+
+The input type **Color** creates a selection field for defining any color. The color can be entered in hexadecimal notation, in RGB notation or in HSL notation. It is possible to select a color using a picker or to enter exact color values.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-color _value="#d4fcf4" _label="Hintergrundfarbe" _icons='{"right": "codicon codicon-symbol-color"}'></kol-input-color>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-color _value="#d4fcf4" _label="Hintergrundfarbe" _icons='{"right": "codicon codicon-symbol-color"}'></kol-input-color>
+
+## Usage
+
+Set the default color using the `_value` attribute. Use hexadecimal notation (#xxxxxx) for this.
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+Note that the **InputColor** component is not fully accessible. Selecting a color is possible via keyboard control. However, the output of the selected color via screen readers is technically limited.
+See also: [https://github.com/public-ui/kolibri/blob/develop/KNOWN_ISSUES.md#input-color](Known Issues).
+
+For complete accessibility, consider using a ready-made color selection list, e.g. via checkboxes or select fields.
+
+### Keyboard controls
+
+| button | Function |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the input field. When the dialog box is open, you can use the Tab key to switch between the control fields.                  |
+| `Enter` | Opens or closes the component's dialog box. When the pipette is focused, the **_Pipette_** function is started using the Enter key. |
+| `ESC` | Ends the pipette function. Closes the dialog box if the eyedropper function is not active.                                           |
+| `Arrow keys (right/left)` | Move the selection point when the **_color spectrum_** field is focused.                                                                      |
+| `Arrow keys (up/down)` | Changes the selection when the **_color system_** field is focused.                                                                                  |
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-color" />
+
+## Live editor
+
+<LiveEditorCompact component="input-color" />
+
+## Examples
+
+<Configurator component="input-color" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-date.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-date.mdx
@@ -1,0 +1,144 @@
+---
+title: InputDate
+description: Description, specification and examples for the InputDate component.
+---
+
+import Readme from '/readmes/input-date/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputDate
+
+Synonyms: Date Picker, Datetime Picker, Week Picker Month Picker, Time Picker, Calendar
+
+The input type **Date** creates an input field for date values. These can be specific dates, but also weeks, months or times.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-date _type="date" _label="Erstellungsdatum" _icons='{"right": "codicon codicon-calendar"}'></kol-input-date>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-date _type="date" _label="Erstellungsdatum" _icons='{"right": "codicon codicon-calendar"}'></kol-input-date>
+
+#### Remove date
+
+The following example shows a component in React that offers the option of removing the value in the date field using a button.
+
+```jsx
+const ClearableDateInput = () => {
+  const [value, setValue] = useState<Date>();
+  return (
+    <>
+        <KolInputDate
+          _label="Lorem ipsum dolor sit"
+          _value={value}
+          _on={{ onChange: (_, v: Date) => setValue(v) }}
+        />
+        {/* Set null as value to clear the inputs value. */}
+        <KolButton _on={{ onClick: () => setValue(null) }} _label="Clear" />
+    </>
+  );
+};
+```
+
+### Events
+
+Component events can be handled via a `_on` property, which consists of an object with various callback functions:
+
+```js
+kolibriElement._on = {
+	onFocus: (event) => {
+		/* Do something on focus */
+	},
+	onInput: (event, value) => {
+		/* Do something with value or event */
+	},
+	// ...
+};
+```
+
+| Event | trigger | Value |
+| -------- | ------------------------------------------------------------------------------- | ------------------------------------- |
+| onFocus | Element is focused | - |
+| onClick | Element is clicked | - |
+| onInput | Date is set or changes (corresponds to native `input` event) | Date entered as ISO8601 String |
+| onChange | Date is set or changes (corresponds to native `change` event) | Date entered as ISO8601 String |
+| onBlur | Element loses focus | - |
+
+## Usage
+
+The **InputDate** component can be used to capture data. It internally uses the InputNumber component.
+
+<kol-alert _type="info">Beachten Sie, dass im **Firefox** nicht alle **`_types`** der **InputDate**-Komponente funktional sind. Es werden bei den Typen `month`, `time` und `week` keine Auswahldialoge angezeigt.</kol-alert>
+
+The component stands out because it supports numerous number-based input patterns. It is important to note that input behavior can vary from browser to browser and device to device. For example, it is possible to enter 01/01/999999 for the date, even if max=2022-02-02. The field value is still 2022-02-02.
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+The icons in the component cannot be accessed using the Tab key. The component selection aids are opened using the **space bar** or **Enter**. For example, with the type **date** you get a calendar module that can be used to select the desired date using the mouse or keyboard. Alternatively, you can enter the values ​​manually.
+
+### Known issues
+
+There are <kol-link _href="/docs/known-issues#kol-input-date">known accessibility limitations</kol-link> for the input date.
+
+
+
+### Keyboard controls
+
+The input field for time information comes in different versions (date, time, etc.). The 'Tab' key sets the focus on the input field. The device-specific selection dialog can then be opened using the 'Space' key.
+
+> Note: We found in our tests that, depending on the browser version, it is sometimes possible to focus on the calendar icon and sometimes not. Without the implementation of the component having changed. We don't yet know why this is the case. Nevertheless, opening the selection dialog is always possible using the 'Space' key.
+
+| button | Function |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the input field. After receiving focus, the 'Tab' key switches through the input areas. Only then does the 'Tab' key switch to the next input field.                                                                                            |
+| `Empty` | If the input field is focused, a selection dialog can be opened or closed in the browser using the 'space' key. Navigation and selection is done here using the 'Tab' key, the 'arrow' keys and confirmation with the 'Enter' key. |
+| `Arrow keys (left/right)` | When the input field is focused, you can use the 'arrow' keys to switch between the input areas.                                                                                                                                               |
+| `Arrow keys (up/down)` | If an input area is activated, the values ​​can be changed using the arrow keys up and down.                                                                                                                                                 |
+| `Esc` | If a selection dialog is available, it can be closed alternatively using the 'Space' key or the 'Esc' key.                                                                                                                                      |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/2012/WD-html-markup-20120329/input.date.html" _target="_blank"></kol-link>
+- <kol-link _href="https://www.hassellinclusion.com/blog/input-type-date-ready-for-use/" _target="_blank"></kol-link>
+- <kol-link _href="https://a11ysupport.io/tech/html/input(type-date)_element" _target="_blank"></kol-link>
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-date" />
+
+## Live editor
+
+<LiveEditorCompact component="input-date" />
+
+## Examples
+
+<Configurator component="input-date" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-email.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-email.mdx
@@ -1,0 +1,133 @@
+---
+title: InputEmail
+description: Description, specification and examples for the InputEmail component.
+---
+
+import Readme from '/readmes/input-email/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputEmail
+
+The input type **Email** creates an input field for emails.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-email _label="E-Mail-Adresse" _icons='{"right": "codicon codicon-mail"}'></kol-input-email>
+```
+
+### Example
+
+<kol-input-email _label="E-Mail-Adresse" _icons='{"right": "codicon codicon-mail"}'></kol-input-email>
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+## Usage
+
+Use the **InputEmail** component on forms that require the entry of one or more email addresses.
+
+By default, the component is designed to capture a single email address. Set the **`_multiple`** attribute to capture multiple email addresses. Separate each email address with a comma (,).
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+There is no validation of the recorded email addresses within the component.
+To indicate failed validation, use the `_msg` and `_touched` attributes.
+
+### Keyboard controls
+
+| button | Function |
+| ----- | --------------------------- |
+| `Tab` | Focuses the input field. |
+
+## Character limit and character counter
+
+With the three attributes `_max-length`, `_max-length-behavior` and `_has-counter`, the input length can be flexibly limited and at the same time provide visual feedback.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| ---------------------- | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_has-counter` | `boolean` | `false` | Global switch for the character counter. Only if this attribute is **set (= true)** will a counter be output.                                                                                                                                                           |
+| `_max-length` | `number` | — | Maximum number of characters allowed. Effective only if `_has-counter` is active.                                                                                                                                                                                                              |
+| `_max-length-behavior` | `"hard" \| "soft"` | `"hard"` | Specifies how the limit is handled **if** `_max-length` is set:<br />- **hard**: Additionally sets the native `maxlength` attribute and prevents further input.<br />- **soft**: Allows further input; the counter shows remaining or exceeded characters. |
+
+### Output variants
+
+| case | `_has-counter` | `_max-length` | `_max-length-behavior` | Visible text |
+| ---: | --------------------- | ------------- | ---------------------- | -------------------------------------------------------- |
+| 1 | *(empty)* or `false` | — | — | — (no counter) |
+| 2 | `true` | *(empty)* | — | `n character` |
+| 3 | `true` | 5 | *(empty)* or `hard` | `n/5 characters` |
+| 4 | `true` | 5 | `soft` | `3 characters still available`<br />*(or `3 characters too many`)* |
+
+> If `_max-length-behavior="soft"` is used, **the native `maxlength` attribute is *not* set** - so the input field is not hard-limited.
+
+### Accessibility
+
+* The counter updates with a **500ms** delay so that screen reader events are concentrated and do not interrupt typing.
+* For screen readers, a hidden text that is only visible to assistive technologies is also displayed, such as:
+*“You can enter up to 10 characters.”*
+
+### Examples
+
+```html
+<!-- Nur Zähler -->
+<kol-input-email _label="E-Mail-Adresse" _has-counter></kol-input-email>
+
+<!-- Harte Begrenzung auf 5 Zeichen -->
+<kol-input-email _label="E-Mail-Adresse" _has-counter _max-length="5"></kol-input-email>
+
+<!-- Weiche Begrenzung auf 5 Zeichen -->
+<kol-input-email
+  _label="E-Mail-Adresse"
+  _has-counter
+  _max-length="5"
+  _max-length-behavior="soft">
+</kol-input-email>
+```
+
+### Summary
+
+* Without `_has-counter` there is **never** a counter.
+* With `_has-counter` **and without** `_max-length` only the currently entered number of characters is displayed.
+* With `_has-counter` **and** `_max-length`, `_max-length-behavior` determines whether the limit is implemented hard (`hard`) or softly (`soft`).
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+- <kol-link _href="https://www.jotform.com/blog/html5-datalists-what-you-need-to-know-78024/" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-email" />
+
+## Live editor
+
+<LiveEditorCompact component="input-email" />
+
+## Examples
+
+<Configurator component="input-email" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-file.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-file.mdx
@@ -1,0 +1,79 @@
+---
+title: InputFile
+description: Description, specification and examples for the InputFile component.
+---
+
+import Readme from '/readmes/input-file/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputFile
+
+Synonyms: Upload, File Uploader, File Picker, File Selector
+
+The input type **File** creates an input field for uploads, for example. One or more files can be selected.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-file _label="Bild hochladen" _accept="image/png, image/jpeg, application/pdf" _icons='{"right": "codicon codicon-device-camera"}'></kol-input-file>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|--------------------------------------------------------------------------------|--------------------------------|
+| `focus` | Input field is focused | - |
+| `click` | Input field is clicked | - |
+| `input` | One or more files are selected (corresponds to native `input` event) | Selected files as FileList |
+| `change` | One or more files are selected (corresponds to native `change` event) | Selected files as FileList |
+| `blur` | Input field loses focus | - |
+
+### Example
+
+<kol-input-file _label="Bild hochladen" _accept="image/png, image/jpeg, application/pdf" _icons='{"right": "codicon codicon-device-camera"}'></kol-input-file>
+
+## Usage
+
+Use the **`_accept`** attribute to specify which file types are allowed for selection. If the attribute is not passed or is passed empty, all file types are permitted.
+Possible values ​​and further information can be found in the <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept" _target="_blank" _label="MDN article on the accept attribute"></kol-link>.
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+- Allow only the file types needed for program execution to be uploaded. Failure to restrict the file types that can be uploaded can be a significant security risk.
+- Limit the size of files you want to allow for upload.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| ----- | --------------------------------------------------------------- |
+| `Tab` | Focuses the input field and calls the file selection dialog. |
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-file" />
+
+## Live editor
+
+<LiveEditorCompact component="input-file" />
+
+## Examples
+
+<Configurator component="input-file" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-number.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-number.mdx
@@ -1,0 +1,71 @@
+---
+title: InputNumber
+description: Description, specification and examples for the InputNumber component.
+---
+
+import Readme from '/readmes/input-number/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputNumber
+
+The input type **Number** creates an input field for numbers.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-number _value="74" _label="ZAHL!" _icons='{"right": "codicon codicon-dashboard"}'></kol-input-number>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-number _value="74" _label="ZAHL!" _icons='{"right": "codicon codicon-dashboard"}'></kol-input-number>
+
+## Usage
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+### Keyboard controls
+
+| button | Function |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the input field.                                                                                                                          |
+| `Arrow keys (up/down)` | Increases or decreases the value within the **`_min`** and **`_max`** attributes according to the step size specified in the **`_step`** attribute. |
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-number" />
+
+## Live editor
+
+<LiveEditorCompact component="input-number" />
+
+## Examples
+
+<Configurator component="input-number" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-password.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-password.mdx
@@ -1,0 +1,125 @@
+---
+title: InputPassword
+description: Description, specification and examples for the InputPassword component.
+---
+
+import Readme from '/readmes/input-password/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputPassword
+
+The input type **Password** creates an input field for passwords. The input is masked using dot symbols.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-password _label="Passwort" _smartButton='{"_icons": "codicon codicon-eye", "_hideLabel": true, "_label": "Passwort anzeigen"}'></kol-input-password>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-password _label="Passwort" _smartButton='{"_icons": "codicon codicon-eye", "_hideLabel": true, "_label": "Passwort anzeigen"}'></kol-input-password>
+
+## Usage
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| ----- | --------------------------- |
+| `Tab` | Focuses the input field. |
+
+## Character limit and character counter
+
+With the three attributes `_max-length`, `_max-length-behavior` and `_has-counter`, the input length can be flexibly limited and at the same time provide visual feedback.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| ---------------------- | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_has-counter` | `boolean` | `false` | Global switch for the character counter. Only if this attribute is **set (= true)** will a counter be output.                                                                                                                                                           |
+| `_max-length` | `number` | — | Maximum number of characters allowed. Effective only if `_has-counter` is active.                                                                                                                                                                                                              |
+| `_max-length-behavior` | `"hard" \| "soft"` | `"hard"` | Specifies how the limit is handled **if** `_max-length` is set:<br />- **hard**: Additionally sets the native `maxlength` attribute and prevents further input.<br />- **soft**: Allows further input; the counter shows remaining or exceeded characters. |
+
+### Output variants
+
+| case | `_has-counter` | `_max-length` | `_max-length-behavior` | Visible text |
+| ---: | --------------------- | ------------- | ---------------------- | -------------------------------------------------------- |
+| 1 | *(empty)* or `false` | — | — | — (no counter) |
+| 2 | `true` | *(empty)* | — | `n character` |
+| 3 | `true` | 5 | *(empty)* or `hard` | `n/5 characters` |
+| 4 | `true` | 5 | `soft` | `3 characters still available`<br />*(or `3 characters too many`)* |
+
+> If `_max-length-behavior="soft"` is used, **the native `maxlength` attribute is *not* set** - so the input field is not hard-limited.
+
+### Accessibility
+
+* The counter updates with a **500ms** delay so that screen reader events are concentrated and do not interrupt typing.
+* For screen readers, a hidden text that is only visible to assistive technologies is also displayed, such as:
+*“You can enter up to 10 characters.”*
+
+### Examples
+
+```html
+<!-- Nur Zähler -->
+<kol-input-password _label="Passwort" _has-counter></kol-input-password>
+
+<!-- Harte Begrenzung auf 5 Zeichen -->
+<kol-input-password _label="Passwort" _has-counter _max-length="5"></kol-input-password>
+
+<!-- Weiche Begrenzung auf 5 Zeichen -->
+<kol-input-password
+  _label="Passwort"
+    _has-counter
+  _max-length="5"
+  _max-length-behavior="soft">
+</kol-input-password>
+```
+
+### Summary
+
+* Without `_has-counter` there is **never** a counter.
+* With `_has-counter` **and without** `_max-length` only the currently entered number of characters is displayed.
+* With `_has-counter` **and** `_max-length`, `_max-length-behavior` determines whether the limit is implemented hard (`hard`) or softly (`soft`).
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-password" />
+
+## Live editor
+
+<LiveEditorCompact component="input-password" />
+
+## Examples
+
+<Configurator component="input-password" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-radio.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-radio.mdx
@@ -1,0 +1,112 @@
+---
+title: InputRadio
+description: Description, specification and examples for the InputRadio component.
+---
+
+import Readme from '/readmes/input-radio/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputRadio
+
+Synonyms: Choice Group, Radio Buttons
+
+The **InputRadio** component consists of a collection of radio elements and thus represents a choice between different values. Only a single value can be selected at a time. Selected radio elements are usually displayed with a filled and visually highlighted circle.
+
+<kol-alert _alert _heading="Hinweis" _level="1" _type="info">
+The input radio is used to display a selection option where at least and a maximum of one selection can be made. This means that an input radio cannot occur individually. Because of this, we implemented the component as a list component.
+</kol-alert><br/>
+
+## Construction
+
+### Code
+
+```html
+<kol-input-radio _options='[{"label":"Herr","value":"Herr"},{"label":"Frau","value":"Frau"}, {"label":"Firma","value":"Firma"}]'></kol-input-radio>
+```
+
+### Example
+
+<kol-input-radio _options='[{"label":"Herr","value":"Herr"},{"label":"Frau","value":"Frau"}, {"label":"Firma","value":"Firma"}]'></kol-input-radio>
+
+## Usage
+
+The individual radio elements within the **InputRadio** component are passed as a JSON object via the **_\_options_** attribute.
+
+The JSON object expects the following values ​​for each radio element:
+
+**`label`** = Label of the radio element
+
+**`value`** = Value of the radio element
+
+Example of creating the JSON object to define the radio elements:
+
+```html
+[ { label: 'Herr', value: 'Herr', }, { label: 'Frau', value: 'Frau', }, { label: 'Firma', value: 'Firma', }, ];
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|-----------------------------|-----------------------------|
+| `focus` | An option is focused | - |
+| `blur` | An option loses focus | - |
+| `input` | Option is selected | `value` attribute of option |
+| `change` | Option is selected | `value` attribute of option |
+
+### onChange
+
+<kol-alert _heading="Hinweis für Versionen <2" _type="info">event.target.value enthält die Nummer der Checkbox mit einem '-' davor.</kol-alert>
+
+```jsx
+<kol-input-radio
+	_options={[
+		{ label: 'Herr', value: 'Herr' },
+		{ label: 'Frau', value: 'Frau' },
+		{ label: 'Firma', value: 'Firma' },
+	]}
+	_on={{ onChange: (_event, value) => setValue(value) }}
+></kol-input-radio>
+```
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+- At least one value is always selected. Similar to the behavior of a Select selection. (<kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio#selecting_a_radio_button_by_default" _target="_blank"></kol-link>)
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| -------------- | ------------------------------------------------------------------------------------------------ |
+| `Tab` | Focuses on the first radio element, but does not activate it.                                     |
+| `Empty` | Activates the first radio element after the RadioGroup has been jumped to using the Tab key. |
+| `arrow keys` | Cycles through all radio elements and activates the currently focused element.                   |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#radiobutton" _target="_blank"></kol-link>
+- <kol-link _href="https://www.w3schools.com/tags/att_input_type_radio.asp" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio" _target="_blank"></kol-link>
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-radio" />
+
+## Live editor
+
+<LiveEditorCompact component="input-radio" />
+
+## Examples
+
+<Configurator component="input-radio" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-range.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-range.mdx
@@ -1,0 +1,88 @@
+---
+title: InputRange
+description: Description, specification, and examples for the InputRange component.
+---
+
+import Readme from '/readmes/input-range/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+#InputRange
+
+Synonyms: Slider
+
+The **Range** input type creates an interactive element that allows values ​​to be changed by moving a slider.
+
+## Construction
+
+### Code
+
+```html
+<kol-input-range
+	_label="Wertebereich"
+	_min="100"
+	_max="200"
+	_value="100"
+	_step="20"
+	_icons='{"left": "codicon codicon-arrow-small-down", "right": "codicon codicon-arrow-small-up"}'
+></kol-input-range>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-range
+_label="value range"
+_min="100"
+_max="200"
+_value="100"
+_step="20"
+_icons='{"left": "codicon codicon-arrow-small-down", "right": "codicon codicon-arrow-small-up"}'></kol-input-range>
+
+## Usage
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| -------------- | ------------------------------------------------------ |
+| `Tab` | Focuses the input field.              |
+| `arrow keys` | Change the value of the range component. |
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-range" />
+
+## Live editor
+
+<LiveEditorCompact component="input-range" />
+
+## Examples
+
+<Configurator component="input-range" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-text.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-text.mdx
@@ -1,0 +1,149 @@
+---
+title: InputText
+description: Description, specification and examples for the InputText component.
+---
+
+import Readme from '/readmes/input-text/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import { PropertyMsgUsage } from '@site/src/components/PropertyMsgUsage';
+
+# InputText
+
+Synonyms: Text Field
+
+The input type **Text** creates an input field for normal text, search terms, URLs or phone numbers.
+
+The component has known issues regarding browser dependency and accessibility. Further information can be found at [KNOWN_ISSUES.md](https://github.com/public-ui/kolibri/blob/develop/KNOWN_ISSUES.md).
+
+## Construction
+
+### Code
+
+```html
+<kol-input-text
+  _type="text"
+  _label="Texteingabe"
+  _icons='{"left": "codicon codicon-arrow-left", "right": {"icon": "codicon codicon-arrow-right", "style": {"font-size": "200%"}}}'
+></kol-input-text>
+<kol-input-text _type="text" _label="Deaktiviert" _disabled></kol-input-text>
+<kol-input-text _type="text" _label="Schreibgeschützt" _read-only></kol-input-text>
+<kol-input-text
+  _type="text"
+  _label="Mit Button"
+  _smart-button='{"_icons": "codicon codicon-chrome-close", "_hideLabel": true, "_label": "Löschen"}'
+></kol-input-text>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+<kol-input-text _type="text" _label="Texteingabe" _icons='{"left": "codicon codicon-arrow-left", "right": {"icon": "codicon codicon-arrow-right", "style": {"font-size": "200%"}}}'></kol-input-text>
+<kol-input-text _type="text" _label="Deaktiviert" _disabled></kol-input-text>
+<kol-input-text _type="text" _label="Schreibgeschützt" _read-only></kol-input-text>
+<kol-input-text
+_type="text"
+_label="With button"
+_smart-button='{"_icons": "codicon codicon-chrome-close", "_hideLabel": true, "_label": "Delete"}'></kol-input-text>
+
+
+## Usage
+
+### Best practices
+
+- Make sure to set `id` and `name` correctly so that the data is sent when you submit the form.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| ----- | ------------------------------------- |
+| `Tab` | Focuses the input field.           |
+| `ESC` | Deletes the content (Type = Search only). |
+
+## Character limit and character counter
+
+With the three attributes `_max-length`, `_max-length-behavior` and `_has-counter`, the input length can be flexibly limited and at the same time provide visual feedback.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| ---------------------- | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_has-counter` | `boolean` | `false` | Global switch for the character counter. Only if this attribute is **set (= true)** will a counter be output.                                                                                                                                                           |
+| `_max-length` | `number` | — | Maximum number of characters allowed. Effective only if `_has-counter` is active.                                                                                                                                                                                                              |
+| `_max-length-behavior` | `"hard" \| "soft"` | `"hard"` | Specifies how the limit is handled **if** `_max-length` is set:<br />- **hard**: Additionally sets the native `maxlength` attribute and prevents further input.<br />- **soft**: Allows further input; the counter shows remaining or exceeded characters. |
+
+### Output variants
+
+| case | `_has-counter` | `_max-length` | `_max-length-behavior` | Visible text |
+| ---: | --------------------- | ------------- | ---------------------- | -------------------------------------------------------- |
+| 1 | *(empty)* or `false` | — | — | — (no counter) |
+| 2 | `true` | *(empty)* | — | `n character` |
+| 3 | `true` | 5 | *(empty)* or `hard` | `n/5 characters` |
+| 4 | `true` | 5 | `soft` | `3 characters still available`<br />*(or `3 characters too many`)* |
+
+> If `_max-length-behavior="soft"` is used, **the native `maxlength` attribute is *not* set** - so the input field is not hard-limited.
+
+### Accessibility
+
+* The counter updates with a **500ms** delay so that screen reader events are concentrated and do not interrupt typing.
+* For screen readers, a hidden text that is only visible to assistive technologies is also displayed, such as:
+*“You can enter up to 10 characters.”*
+
+### Examples
+
+```html
+<!-- Nur Zähler -->
+<kol-input-text _label="Texteingabe" _has-counter></kol-input-text>
+
+<!-- Harte Begrenzung auf 5 Zeichen -->
+<kol-input-text _label="Texteingabe" _has-counter _max-length="5"></kol-input-text>
+
+<!-- Weiche Begrenzung auf 5 Zeichen -->
+<kol-input-text
+  _label="Texteingabe"
+  _has-counter
+  _max-length="5"
+  _max-length-behavior="soft">
+</kol-input-text>
+```
+
+### Summary
+
+* Without `_has-counter` there is **never** a counter.
+* With `_has-counter` **and without** `_max-length` only the currently entered number of characters is displayed.
+* With `_has-counter` **and** `_max-length`, `_max-length-behavior` determines whether the limit is implemented hard (`hard`) or softly (`soft`).
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+- <kol-link _href="https://www.jotform.com/blog/html5-datalists-what-you-need-to-know-78024/" _target="_blank"></kol-link>
+
+<Readme />
+
+## Usage _msg
+
+<PropertyMsgUsage />
+
+<ExampleLink component="input-text" />
+
+## Live editor
+
+<LiveEditorCompact component="input-text" />
+
+## Examples
+
+<Configurator component="input-text" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/kolibri.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/kolibri.mdx
@@ -1,0 +1,32 @@
+---
+title: KoliBri
+description: Description, specification and examples for the KoliBri component.
+---
+
+import Readme from '/readmes/kolibri/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+
+# KoliBri
+
+This component implements the KoliBri logo.
+
+## Construction
+
+### Code
+
+```html
+<kol-kolibri></kol-kolibri> <kol-kolibri _labeled="false"></kol-kolibri>
+```
+
+## Examples
+
+<kol-kolibri></kol-kolibri>
+<kol-kolibri _labeled="false"></kol-kolibri>
+
+## Accessibility
+
+<Readme />
+
+## Live editor
+
+<LiveEditorCompact component="kolibri" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/link-button.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/link-button.mdx
@@ -1,0 +1,56 @@
+---
+title: LinkButton
+description: Description, specification and examples for the LinkButton component.
+---
+
+import Readme from '/readmes/link-button/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# LinkButton
+
+The LinkButton is semantically a link and has the design of a button. For this purpose, all relevant properties of the link component are adopted and expanded to include the design-determining properties of the button.
+For more information about the appearance, see the <kol-link _href="../components/button" _label="Button page"></kol-link>.
+
+## Construction
+
+### Code
+
+```html
+<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
+<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
+<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
+<kol-link-button _href="#" _label="Secondary" _variant="danger"></kol-link-button>
+<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------|------------------|
+| `click` | Element is clicked | `_href` property |
+
+### Example
+
+<div class="flex gap-2">
+	<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
+	<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
+	<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
+	<kol-link-button _href="#" _label="Danger" _variant="danger"></kol-link-button>
+	<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
+</div>
+
+<Readme />
+
+<ExampleLink component="link-button" />
+
+## Live editor
+
+<LiveEditorCompact component="link-button" />
+
+## Examples
+
+<Configurator component="link-button" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/link.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/link.mdx
@@ -1,0 +1,104 @@
+---
+title: Link
+description: Description, specification and examples for the Link component.
+---
+
+import Readme from '/readmes/link/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Link
+
+The **Link** component renders a link optimized for accessibility, which can be output as text, as an icon or in combination.
+
+## Construction
+
+### Code
+
+```html
+<p>
+	In diesem Absatz wird ein Link gesetzt, der keine weiteren Attribute enthält.
+	<kol-link _href="https://www.w3.org" _target="_blank">Hier steht ein Link</kol-link>Er wird standardmäßig als
+	<i>
+		<b>inline-Element</b>
+	</i>
+	ausgegeben.
+</p>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------|------------------|
+| `click` | Element is clicked | `_href` property |
+
+### Example
+
+<p>
+In this paragraph a link is set that does not contain any other attributes.
+	<kol-link _href="https://www.w3.org" _target="_blank">Hier steht ein Link</kol-link>Er wird standardmäßig als <i>
+	<b>inline-Element</b>
+</i> ausgegeben.
+</p>
+
+## Usage
+
+### Link within a continuous text with icon and text
+
+<p>
+	<kol-link _icons="codicon codicon-home">Ich bin ein Link mit Icon links</kol-link><br/>
+	<kol-link _icons="codicon codicon-home">
+I am a link with an icon on the right
+	</kol-link>
+Lorem, ipsum dolor sit amet consectetur adipisicing elit. Ea optio deleniti fuga quos molestias, voluptate nobis
+nemo, incidunt excepturi facilis, amet ducimus minus quae corporis eligendi cum distinctio. Fugit, repellendus.
+	<kol-link _icons="codicon codicon-home">Ich bin ein Link mit Icon links</kol-link>. Lorem, ipsum dolor sit amet consectetur adipisicing
+elite Ea optio deleniti fuga quos molestias, voluptate nobis nemo, incidunt excepturi
+	<kol-link _icons="codicon codicon-home">Ich bin ein Link mit Icon rechts</kol-link>
+facilis, amet ducimus minus quae corporis eligendi cum distinctio. Fugit, repellendus.
+</p>
+
+## `aria-current` service
+
+So that the link component automatically creates a [`aria-current` tag](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current)
+can set, it must be informed via the ariaCurrent service which page is currently active:
+
+```typescript
+import { setCurrentLocation } from '@public-ui/components';
+
+/* Bei jedem Seitenwechsel aufrufen: */
+setCurrentLocation('/path/to/page');
+```
+
+The location string passed must correspond exactly to the `href` attribute of the link.
+
+<!--### Best practices
+
+### Use cases-->
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| ------- | ------------------------------- |
+| `Tab` | Focuses the link element.    |
+| `Enter` | Calls up the provided link. |
+
+<Readme />
+
+<ExampleLink component="link" />
+
+## Live editor
+
+<LiveEditorCompact component="link" />
+
+## Examples
+
+<Configurator component="link" sample="basic" />
+<Configurator component="link" sample="icons" />
+<Configurator component="link" sample="image" />
+<Configurator component="link" sample="target" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/modal.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/modal.mdx
@@ -1,0 +1,107 @@
+---
+title: Modal
+description: Description, specification and examples for the Modal component.
+---
+
+import Readme from '/readmes/modal/readme.md';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Modal
+
+Synonyms: dialogue, prompt
+
+Using the **Modal** component, additional information or input forms can be displayed in a dialog window. An open **modal** can be closed via **ESC**.
+The **Modal** component is hidden by default. It is usually only displayed after clicking on a button or other trigger. The background of the window is deactivated and only the content of the modal window is active.
+
+### How it works
+
+The **Modal** creates the basis for barrier-free overlays and makes it possible to display any HTML content. For example, a Dialog component would be a composition of a Card component inserted into a **Modal** component.
+
+As soon as a **modal** is opened, all selectable elements in the website are deactivated, except those within the active modal.
+
+### Construction
+
+#### Code
+
+```html
+<kol-modal id="test-modal" _label="Beschreibung zur Modalbox">
+	<kol-card _label="Vorgang löschen">
+		<div>
+			<p>Wollen Sie den Vorgang wirklich löschen?</p>
+			<kol-button class="close-modal" _label="Ok" _variant="primary"></kol-button>
+			<kol-button class="close-modal" _label="Abbrechen"></kol-button>
+		</div>
+	</kol-card>
+</kol-modal>
+
+<kol-button id="modal-open-button" _label="Modal öffnen"></kol-button>
+
+<script>
+	const modal = document.querySelector('#test-modal');
+	const modalOpenButton = document.querySelector('#modal-open-button');
+
+	document.querySelectorAll('.close-modal').forEach((buttonElement) => {
+		buttonElement._on = {
+			onClick: () => modal.closeModal(),
+		};
+	});
+	modalOpenButton._on = { onClick: () => modal.openModal() };
+</script>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------------|-------|
+| `close` | Component is closing | - |
+
+### Usage
+
+Use the **`_width`** attribute to specify the desired width of the modal box. It is always displayed in the middle of the screen in the selected size.
+
+Since the modal is decoupled from the actual page content but provides partial blocking of the content, it must also provide a way to enable closing (unblocking) from the modal context.
+
+<kol-alert _type="info">Es wird empfohlen einen Close-Button oben rechts einzubauen.</kol-alert>
+
+To open the modal you can use `openModal` method using a DOM reference, to close `closeModal`.
+
+#### Best practices
+
+- Use the modal box to display further information on a topic.
+- Use Modalbox to make large content visually more compact.
+- Avoid placing important information such as legal topics that users need to respond to in modal boxes.
+
+#### Use cases
+
+- Use the modal box to help explain individual input fields in forms.
+- Use the modal box to display additional information only after the user requests it.
+- Use the modal box to display feedback on save processes or similar, e.g. **_Thank you for your feedback_** after submitting a form.
+
+### Accessibility
+
+> The standard optical output of the component is optimized to implement accessibility. If you use your own custom styles, this may limit accessibility.
+
+The **modal** is implemented so that the focus is on it when it is opened. Elements outside the modal can then no longer be focused.
+
+For optimal output of the **Modal** component in screen readers, make sure to set the **`aria-label`** attribute correctly.
+
+Furthermore, there is only ever a maximum of one active modal, which deactivates all selectable elements except those within its own modal. It is important to note that KoliBri only disables elements that are in the browser side area. Focusing the browser menu is still possible.
+
+#### Keyboard controls
+
+| button | Function |
+| ----- | ----------------------------------------------------------------------------------------------- |
+| `Tab` | When the modal is open, all focusable elements are jumped to in order. |
+| `ESC` | Closes the modal.                                                                         |
+
+### Links and references
+
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices/#dialog_modal" _target="_blank"></kol-link>
+- <kol-link _href="https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="modal" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/nav.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/nav.mdx
@@ -1,0 +1,125 @@
+---
+title: Nav
+description: Description, specification and examples for the Nav component.
+---
+
+import Readme from '/readmes/nav/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Nav
+
+Synonyms: navigation, menu, sidebar, dropdowns (menu)
+
+A **Navigation Bar** is a group of related links or navigation elements that, when clicked, perform an action or display content. It navigates users directly to specific content on the current page or to external pages. It also serves as a control (similar to tabs) for users to show, hide and switch between content.
+
+**KoliBri** provides an extensively configurable, vertical **navigation bar** that displays several levels and can be varied in width.
+Higher-level menu items that contain submenu items are displayed with a **plus icon** on the right edge. If the higher-level menu item is opened with the plus icon, the plus icon automatically changes to a **minus icon**, with which the menu item can be closed again.
+
+Active menu items are shown with a colored marker.
+
+The width of the **Nav** component can be changed using an optional button below the navigation. In the smallest width the menu titles are hidden and only
+the icons are still output.
+
+## Construction
+
+### Code
+
+```html
+<kol-nav
+	_label="Hauptmenü"
+	_links="[
+    {
+      '_href': 'startseite',
+      '_icons': 'codicon codicon-home',
+      '_label': 'Startseite2',
+      '_children': [
+        {
+          '_href': 'startseite/1-untermenuepunkt',
+          '_icons': 'codicon codicon-home',
+          '_label': '1. Untermenüpunkt'
+        },
+        {
+          '_href': 'startseite/2-untermenuepunkt',
+          '_icons': 'codicon codicon-home',
+          '_label': '2. Untermenüpunkt'
+        }
+      ]
+    },
+    {
+      '_href': 'unterseite',
+      '_icons': 'codicon codicon-home',
+      '_label': '2. Menüpunkt'
+    }
+  ]"
+	_has-compact-button
+></kol-nav>
+```
+
+### Example
+
+<kol-nav _label="Hauptmenü" _links="[{'_href':'startseite','_icons':'codicon codicon-home','_label':'Startseite','_children':[{'_href':'startseite/1-untermenuepunkt','_icons':'codicon codicon-home','_label':'1. Untermenüpunkt'},{'_href':'startseite/2-untermenuepunkt','_icons':'codicon codicon-home','_label':'2. Untermenüpunkt'}]},{'_href':'unterseite','_icons':'codicon codicon-home','_label':'2. Menüpunkt'}]" _has-compact-button></kol-nav>
+
+## Usage
+
+### Define links in the navigation bar
+
+The navigation structure is passed to the **`_links`** attribute as an object or JSON string. The structure is built as a value/parameter pair:
+To create submenu items, extend the JSON structure with the additional attribute **`_children`** in the parent element.
+
+```js
+[
+	{
+		_href: 'startseite',
+		_icons: 'codicon codicon-home',
+		_label: 'Startseite',
+		_children: [
+			{ _href: 'startseite/1-untermenuepunkt', _icons: 'codicon codicon-home', _label: '1. Untermenüpunkt' },
+			{ _href: 'startseite/2-untermenuepunkt', _icons: 'codicon codicon-home', _label: '2. Untermenüpunkt' },
+		],
+	},
+	{ _href: 'unterseite', _icons: 'codicon codicon-home', _label: '2. Menüpunkt' },
+];
+```
+
+### Show compact navigation bar
+
+To display the navigation bar in the compact view, set the **`_hide-label`** attribute.
+
+### Best practices
+
+- Use **navigation bars** to represent **navigation** or navigation-like actions (e.g. internal or external links, logging out, controlling visibility on the page).
+- Use the label to provide a clear and concise description of the content related to that particular navigation element.
+- Do not use **navigation bars** for actions that are better presented as buttons (e.g. “Save”, “Delete”, “Add Item to Cart”).
+- Do not stack multiple **navigation bars** right next to each other.
+- Do not use **navigation bars** to compare content (e.g. different performances).
+- Consider the number of navigation items you add to the **Navigation Bar**. If you feel the number is becoming too large, consider alternative approaches to presenting the content or use a different navigation pattern/component.
+
+### Use cases
+
+- Use **Navigation Bars** as in-page navigation on a landing page.
+- Use **Navigation Bars** to organize related information on a landing page.
+- Use **navigation bars** to classify offers or benefits into different categories (e.g. forms).
+- Use **Navigation Bars** to divide FAQs into different categories.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses on the first menu item in the navigation. Each menu item can then be accessed using the Tab key. If the Has-compact button has been activated, it can also be accessed with the Tab key. |
+| `Enter` | Expands/closes sub-items if a collapse button is focused, activates the button or opens the link otherwise.                                                                                  |
+
+<Readme />
+
+<ExampleLink component="nav" />
+
+## Live editor
+
+<LiveEditorCompact component="nav" />
+
+## Examples
+
+<Configurator component="nav" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/pagination.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/pagination.mdx
@@ -1,0 +1,74 @@
+---
+title: Pagination
+description: Description, specification and examples for the Pagination component.
+---
+
+import Readme from '/readmes/pagination/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Pagination
+
+With the help of the **Pagination** component, extensive, divided content, such as search results, can be scrolled through in order.
+
+## Construction
+
+### Code
+
+```html
+<div>
+	<kol-pagination _max="100" _page="6"></kol-pagination>
+	<kol-pagination _max="100" _page="6" _sibling-count="2"></kol-pagination>
+	<kol-pagination _max="100" _page="6" _sibling-count="0" _boundary-count="2"></kol-pagination>
+</div>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|------------------|------------------------- |----------------------------------|
+| `click` | Page is clicked | Number of selected page |
+| `changePage` | Page is clicked | Number of selected page |
+| `changePageSize` | Page size is changed | New page size |
+
+### Example
+
+<div class="grid gap-2">
+	<kol-heading _level="3" _label="Standardausgabe nur mit aktuellem Element"></kol-heading>
+	<kol-pagination _max="100" _page="6" _has-buttons="false"></kol-pagination>
+	<kol-heading _level="3" _label="Ausgabe 2 Elemente links und rechts dem aktuellen Element (_sibling)"></kol-heading>
+	<kol-pagination _max="100" _page="6" _sibling-count="2"></kol-pagination>
+	<kol-heading _level="3" _label="Ausgabe 2 Elemente links und rechts (_boundary-count)"></kol-heading>
+	<kol-pagination _max="100" _page="6" _sibling-count="0" _boundary-count="2"></kol-pagination>
+</div>
+
+## Usage
+
+The **Pagination** component can be configured via your properties.
+
+- The **`_max`** attribute determines the total number of elements.
+- The **`boundary-count`** attribute determines the number of elements that are displayed on the right and left in the **Pagination** component, while the remaining elements
+- The **`_page`** attribute sets the currently active element. This is highlighted in color.
+- The **`_sibling-count`** attribute can be used to determine how many elements should be displayed to the left and right of the current one.
+
+<!-- ### Best practices -->
+
+### Use cases
+
+The **Pagination** component can be used in a variety of ways. Especially where extensive content is to be displayed on a content page, it helps to improve the structure and clarity.
+Classic areas of application for pagination include blog-like content, lists and tables. Pagination can also be used for certain navigation tasks within a page.
+
+<Readme />
+
+<ExampleLink component="pagination" />
+
+## Live editor
+
+<LiveEditorCompact component="pagination" />
+
+## Examples
+
+<Configurator component="pagination" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/popover-button.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/popover-button.mdx
@@ -1,0 +1,45 @@
+---
+title: PopoverButton
+description: Description and specification for the PopoverButton component.
+---
+
+import { ExampleLink } from '@site/src/components/ExampleLink';
+import Readme from '/readmes/popover-button/readme.md';
+
+# PopoverButton
+
+The PopoverButton is a component that combines a button with an associated popover menu. The popover is shown and hidden by clicking on the button. The label of the button can be set using the `_label` attribute. The position of the popover can be controlled via `_popover-align`, whereby the popover can be placed either above, to the right, below or to the left of the button.
+
+The PopoverButton is particularly suitable for:
+
+- Additional Information
+- Context menus
+- Fold-out controls
+
+## Construction
+
+### Code
+
+```html
+<kol-popover-button _label="Weitere Informationen" _icons="codicon codicon-info" _popover-align="right">
+	Weitere Informationen im Popover.
+</kol-popover-button>
+```
+
+### Example
+
+<kol-popover-button _label="Weitere Informationen" _icons="codicon codicon-info" _popover-align="right">
+Further information in the popover.
+</kol-popover-button>
+
+<Readme />
+
+<ExampleLink component="popover-button" />
+
+## Live editor
+
+[//]: # (<LiveEditorCompact component="popover-button" />)
+
+## Examples
+
+[//]: # (<Configurator component="popover-button" sample="basic" />)

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/popover.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/popover.mdx
@@ -1,0 +1,21 @@
+---
+title: Popover
+description: Description and specification for the Popover component.
+---
+
+# Popover
+
+<kol-badge _label="untested"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da der vollständige Barrierefreiheitstest noch aussteht. Der vollständige Test kann bei neuen Komponenten und Funktionalitäten auch erst nach einem abgeschlossenen Release erfolgen.
+
+The **Popover** component provides a way to put additional content in a temporary element that is arranged around its trigger element, similar to <kol-link _href="" _label="Tooltip"></kol-link>.
+The trigger element is always the preceding element in the HTML (previousSibling).
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------|-----------------------------|-------|
+| `close` | Component is closing | - |
+
+<kol-alert _type="info" _variant="card">Die **Popover**-Komponente wird innerhalb von KoliBri verwendet und ist nicht dafür vorgesehen in der Anwendungsentwicklung verwendet zu werden.</kol-alert>

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/progress.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/progress.mdx
@@ -1,0 +1,62 @@
+---
+title: Progress
+description: Description, specification and examples for the Progress component.
+---
+import Readme from '/readmes/progress/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Progress
+
+The **Progress** component creates a progress bar that can be used to provide visual feedback.
+
+## Construction
+
+### Code
+
+```html
+<div>
+	<kol-progress _label="Fortschritt" _variant="bar" _max="100" _value="20"></kol-progress>
+	<kol-progress _label="Fortschritt" _variant="cycle" _max="100" _value="20"></kol-progress>
+</div>
+```
+
+### Example
+
+<kol-progress _label="Fortschritt" _variant="bar" _max="100" _value="20"></kol-progress>
+<kol-progress _label="Fortschritt" _variant="cycle" _max="100" _value="20"></kol-progress>
+
+## Usage
+
+Use the **`_variant`** attribute to control the visual output of the component. Possible values ​​are:
+
+- `bar`: for output as a horizontal progress bar
+- `cycle`: for output as a circular progress bar
+
+Use the **`_max`** attribute to determine the maximum value of the component, the minimum is always 0.
+
+Use the **`_value`** attribute to determine the current value of the component.
+
+<!--### Best practices
+
+### Use cases-->
+
+<!-- ## Barrierefreiheit -->
+
+## Links and references
+
+- <kol-link _href="https://developer.mozilla.org/de/docs/Web/HTML/Element/progress" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="progress" />
+
+## Live editor
+
+<LiveEditorCompact component="progress" />
+
+## Examples
+
+<Configurator component="progress" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/quote.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/quote.mdx
@@ -1,0 +1,80 @@
+---
+title: Quote
+description: Description, specification and examples for the Quote component.
+---
+
+import Readme from '/readmes/quote/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Quote
+
+> <kol-badge _label="untested"></kol-badge> This new component is marked as untested because the full accessibility test is still pending. The full test of new components and functionalities can only take place after a completed release.
+
+The **Quote** component has two variants, a short body text ("inline") and an indented ("block") variant. Both versions contain a link to the source of the quote.
+
+## Construction
+
+### Code
+
+```html
+<kol-quote
+	_label="RFC 1149"
+	_href="https://datatracker.ietf.org/doc/html/rfc1149"
+	_quote="Avian carriers can provide high delay, low throughput, and low altitude
+								service. The connection topology is limited to a single point-to-point path
+								for each carrier, used with standard carriers, but many carriers can be used
+								without significant interference with each other, outside early spring.
+								This is because of the 3D ether space available to the carriers, in contrast
+								to the 1D ether used by IEEE802.3. The carriers have an intrinsic collision
+								avoidance system, which increases availability."
+	_variant="block"
+>
+</kol-quote>
+<kol-quote
+	_label="RFC 1149"
+	_href="https://datatracker.ietf.org/doc/html/rfc1149"
+	_quote="Avian carriers can provide high delay."
+	_variant="inline"
+></kol-quote>
+```
+
+### Examples
+
+<kol-quote
+_label="RFC 1149"
+_href="https://datatracker.ietf.org/doc/html/rfc1149"
+_quote="Avian carriers can provide high delay, low throughput, and low altitude
+service. The connection topology is limited to a single point-to-point path
+for each carrier, used with standard carriers, but many carriers can be used
+without significant interference with each other, outside early spring.
+This is because of the 3D ether space available to the carriers, in contrast
+to the 1D ether used by IEEE802.3. The carriers have an intrinsic collision
+avoidance system, which increases availability."
+_variant="block"></kol-quote>
+<kol-quote
+_label="RFC 1149"
+_href="https://datatracker.ietf.org/doc/html/rfc1149"
+_quote="Avian carriers can provide high delay."
+_variant="inline"></kol-quote>
+
+## Usage
+
+A heading can be set using **`_label`**, while **`_quote`** contains the actual quote. The origin is set via **`_href`**.
+The `inline` variant is standard, if indented is desired, **`_variant`** can be set to `block`.
+
+## References
+
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/quote" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite" _target="_blank"></kol-link>
+- <kol-link _href="https://www.mediaevent.de/html/quote.html" _target="_blank"></kol-link>
+- <kol-link _href="https://www.mediaevent.de/html/cite.html" _target="_blank"></kol-link>
+- <kol-link _href="https://accessibleweb.com/question-answer/what-is-a-block-quote-and-when-should-i-use-it/" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="quote" />
+
+## Live editor
+
+<LiveEditorCompact component="quote" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/select.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/select.mdx
@@ -1,0 +1,127 @@
+---
+title: Select
+description: Description, specification and examples for the Select component.
+---
+
+import Readme from '/readmes/select/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Select
+
+Synonyms: Datalist, Dropdown
+
+The **Select** component creates a selection list from which one or more predefined options can be selected.
+
+## Construction
+
+### Code
+
+```html
+<kol-select _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'}]" _value="Mrs."> Auswahlfeld </kol-select>
+<kol-select _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'}]" _multiple _value="['Mr.','Company']">
+        Auswahlfeld (Mehrfachauswahl)
+</kol-select>
+<kol-select
+        _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'},{'label':'Herr','value':'Mr2'},{'label':'Frau','value':'Mrs2'},{'label':'Firma','value':'Company2'}]"
+        _rows="4"
+        _value="Mrs."
+>
+        Auswahlfeld mit _rows
+</kol-select>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|-----------------------------|-----------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Option is selected | `value` attribute of option |
+| `change` | Option is selected | `value` attribute of option |
+
+### Example
+
+<kol-select _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'}]" _value="Mrs."> Auswahlfeld </kol-select>
+<kol-select _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'}]" _multiple _value="['Mr.','Company']">
+Selection field (multiple selection)
+</kol-select>
+<kol-select _options="[{'label':'Herr','value':'Mr.'},{'label':'Frau','value':'Mrs.'},{'label':'Firma','value':'Company'},{'label':'Herr','value':'Mr2'},{'label':'Frau','value':'Mrs2'},{'label':'Firma','value':'Company2'}]" _rows="4" _value="Mrs.">Auswahlfeld mit rows</kol-select>
+
+## Usage
+
+The choices are passed to the component as an object or JSON string via the **`_options`** attribute. The values ​​**`label`** and **`value`** must be specified for each option.
+
+Example of the construction of the JSON object:
+
+```json
+[
+        { "label": "Herr", "value": "Mr." },
+        { "label": "Frau", "value": "Mrs." },
+        { "label": "Firma", "value": "Company" }
+]
+```
+
+### Specify individual height
+
+Using the **`_rows`** attribute you can switch from a selection menu to a selection field (like **`_multiple`**) and set its height.
+
+### Best practices
+
+- Do not deactivate options of a select using `disabled`. Screen readers (tested with NVDA) count deactivated options and thus display a higher number of choices.
+- Often the first option is created as “Please select an option” and then deactivated to force a selection. This approach should be avoided.
+- Hiding a disabled option using `aria-hidden` is now blocked by modern browsers. If a wildcard option is needed, use a selectable option with an empty value instead.
+- Use validators to check whether a valid option has been chosen instead of disabling options without giving reasons.
+
+<!-- ## Barrierefreiheit -->
+
+### Keyboard controls
+
+| button | Function |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the selection field.                                                                                                                                                                                                   |
+| `Enter` | Opens or closes the selection list.                                                                                                                                                                                         |
+| `Arrow keys (up/down)` | Changes the activated element in the selection list. This function is also active when the selection list is collapsed. With multiple selection, you must also hold down the shift key to select several entries. |
+
+### `Single-Select-Filter` for Select component
+
+When a value is selected, the Select component returns a list (array) with exactly one
+Return value (in single mode). This can lead to unnecessary effort during further processing. It is easier here to filter the value of the Select component using a <b>SingeSelectFormatter</b>. To do this, insert the following class into the form:
+
+```html
+class SingleSelectFormatter extends AbstractFormatter { public format(value: unknown): unknown { return [value]; } public parse(value: unknown): unknown { if
+(Array.isArray(value) && value.length > 0) { return value[0]; } return value; } }
+```
+
+Then add the formatter to the Select component:
+
+```html
+const singleSelectFormatHandler = new FormatHandler(); singleSelectFormatHandler.formatters.add([new SingleSelectFormatter()]); (this.getInput('kategorie') as
+InputControl).setFormatHandler(singleSelectFormatHandler);
+```
+
+Note that the FormatHandler is first imported into the form.
+
+```html
+import { xxx..., xxx..., FormatHandler, } from '@leanup/form';
+```
+
+## Links and references
+
+- https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109
+
+<Readme />
+
+<ExampleLink component="select" />
+
+## Live editor
+
+<LiveEditorCompact component="select" />
+
+## Examples
+
+<Configurator component="select" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/single-select.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/single-select.mdx
@@ -1,0 +1,63 @@
+---
+title: SingleSelect
+description: Description, specification and examples for the SingleSelect component.
+---
+
+import Readme from '/readmes/single-select/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# SingleSelect
+
+The **SingleSelect** component creates a selection box that combines an input field with a list of selectable options underneath. It also offers a search function to filter the selection.
+
+## Construction
+
+### Code
+
+```html
+<kol-single-select
+	_options="[{'label':'Herr','value':0},{'label':'Frau','value':1},{'label':'Firma','value':2}]"
+	_label="Beispiel"
+	_value="1"
+></kol-single-select>
+```
+
+## Usage
+
+The choices are passed to the component as an object or JSON string via the **`_options`** attribute. The values ​​**`label`** and **`value`** must be specified for each option.
+
+Example of the construction of the JSON object:
+
+```json
+[
+	{ "label": "Herr", "value": 0 },
+	{ "label": "Frau", "value": 1 },
+	{ "label": "Firma", "value": 2 }
+]
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|---------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Option is selected | `value` attribute of option |
+| `change` | Option is selected | `value` attribute of option |
+
+<Readme />
+
+<ExampleLink component="single-select" />
+
+## Live editor
+
+<LiveEditorCompact component="single-select" />
+
+## Examples
+
+<Configurator component="single-select" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/skip-nav.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/skip-nav.mdx
@@ -1,0 +1,72 @@
+---
+title: SkipNav
+description: Description, specification and examples for the SkipNav component.
+---
+
+import Readme from '/readmes/skip-nav/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#SkipNav
+
+A hidden navigation can be created using the **SkipNav** component. It is used to enable visually impaired people to skip over side areas. It only becomes visible after clicking the **Tab key**.
+
+## Construction
+
+### Code
+
+```html
+<kol-skip-nav
+	_label="Ein versteckter Link"
+	_links="[{'_label':'Navigation','_href':'#nav'},{'_label':'Inhalt','_href':'#main'},{'_label':'Kontakt','_href':'#kontakt'},{'_label':'Links','_href':'#links'}]"
+></kol-skip-nav>
+```
+
+### Example
+
+To see the **SkipNav**, click on this text and then go one step further with the Tab key.
+
+<kol-skip-nav _label="Ein versteckter Link" _links="[{'_label':'Navigation','_href':'#nav'},{'_label':'Inhalt','_href':'#main'},{'_label':'Kontakt','_href':'#kontakt'},{'_label':'Links','_href':'#links'}]"></kol-skip-nav>
+
+## Usage
+
+The **SkipNav** is created by passing a JSON object that is responsible for rendering the hidden links.
+
+```js
+[
+	{ _label: 'Navigation', _href: '#nav' },
+	{ _label: 'Inhalt', _href: '#main' },
+	{ _label: 'Kontakt', _href: '#kontakt' },
+	{ _label: 'Links', _href: '#links' },
+];
+```
+
+<!--### Best practices
+
+### Use cases-->
+
+<!-- ## Barrierefreiheit -->
+
+### Keyboard controls
+
+| button | Function |
+| ------- | --------------------------------------------------------------------- |
+| `Tab` | Focuses the SkipNav and allows you to scroll through the menu items. |
+| `Enter` | Calls the link of the focused menu item.                        |
+
+## Links and references
+
+- <kol-link _href="https://webaim.org/techniques/skipnav/" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="skip-nav" />
+
+## Live editor
+
+<LiveEditorCompact component="skip-nav" />
+
+## Examples
+
+<Configurator component="skip-nav" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/spin.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/spin.mdx
@@ -1,0 +1,134 @@
+---
+title: Spin
+description: Description, specification and examples for the spin component.
+---
+import Readme from '/readmes/spin/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Spin
+
+Synonyms: Placeholder, Skeleton, Shimmer
+
+Loading indicators, such as the **Spin** component, inform users about loading or computing processes being carried out by the system. Progress can be communicated through a repeated animation.
+
+## Construction
+
+### Code
+
+```html
+<style>
+	/* https://github.com/vineethtrv/css-loader */
+	.loader {
+		animation: rotation 2s linear infinite;
+		border-color: #444;
+		border-radius: 50%;
+		border-style: solid solid dotted dotted;
+		border-width: 3px;
+		box-sizing: border-box;
+		display: inline-block;
+		height: 48px;
+		position: relative;
+		width: 48px;
+	}
+	.loader::after {
+		animation: rotationBack 1s linear infinite;
+		border-color: #ff3d00;
+		border-radius: 50%;
+		border-style: solid solid dotted;
+		border-width: 3px;
+		box-sizing: border-box;
+		bottom: 0;
+		content: '';
+		height: 24px;
+		left: 0;
+		margin: auto;
+		position: absolute;
+		right: 0;
+		top: 0;
+		transform-origin: center center;
+		width: 24px;
+	}
+
+	@keyframes rotation {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(360deg);
+		}
+	}
+	@keyframes rotationBack {
+		0% {
+			transform: rotate(0deg);
+		}
+		100% {
+			transform: rotate(-360deg);
+		}
+	}
+
+	/* https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#toning_down_the_animation_scaling */
+	@media (prefers-reduced-motion) {
+		.loader {
+			animation-duration: 6s;
+		}
+		.loader::after {
+			animation-duration: 3s;
+		}
+	}
+</style>
+<div>
+	<kol-spin _show></kol-spin>
+	<kol-spin _show _variant="cycle"></kol-spin>
+	<!-- for a11y experts - own animation -->
+	<kol-spin _show _variant="none">
+		<!-- slot for own animation : https://github.com/vineethtrv/css-loader -->
+		<span className="loader" slot="expert"></span>
+	</kol-spin>
+</div>
+```
+
+<kol-alert _label_="Reduce Motion" _level="4" _type="warning">
+If possible, animations should always be avoided. If animations are used, care should always be taken to offer a variant with reduced animation speed. More information can be found here:
+	<kol-link _href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion" _label="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion" _target="_blank"></kol-link>
+</kol-alert>
+
+### Example
+
+<kol-spin _show></kol-spin>
+<kol-spin _show _variant="cycle"></kol-spin>
+<kol-spin _show _variant="none"><span className="loader" slot="expert"></span></kol-spin>
+
+<kol-details _label="CSS Loaders & Spinners" _open>
+There are many different CSS loaders and spinners on the internet. For example, _Vineeth_ offers a whole range of interesting CSS loaders. These can also be used in the KoliBri library. All you have to do is include the link to the corresponding CSS file in the head of the HTML file. The desired animation can then be integrated into the KoliBri component via the Expert slot. Here are some examples (without reduced animation speed):
+	<kol-link _href="https://github.com/vineethtrv/css-loader" _target="_blank" _target="_blank"></kol-link>
+</kol-details>
+
+## Usage
+
+Use the `_show` attribute to specify whether the spin is displayed.
+
+### Best practices
+
+- Use charging indicators to inform users about a charging status or a running process.
+- Use loading indicators in consistent places in the interface to improve user experience.
+
+### Use cases
+
+- Retrieve new or updated search results.
+- Log in to protected areas.
+- Download content.
+- Loading extensive content, e.g. videos.
+
+<Readme />
+
+<ExampleLink component="spin" />
+
+## Live editor
+
+<LiveEditorCompact component="spin" />
+
+## Examples
+
+<Configurator component="spin" sample="basic" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/split-button.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/split-button.mdx
@@ -1,0 +1,49 @@
+---
+title: Split-Button
+description: Description, specification and examples for the Split Button component.
+---
+import Readme from '/readmes/split-button/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Split-Button
+
+<kol-badge _label="untested"></kol-badge> Diese neue Komponente wird als ungetestet markiert, da der vollständige Barrierefreiheitstest noch aussteht. Der vollständige Test kann bei neuen Komponenten und Funktionalitäten auch erst nach einem abgeschlossenen Release erfolgen.
+
+The SplitButton component can be used to display a button that is split into two. This becomes the primary button
+usually used for a main action, while the secondary button opens a context menu ("popover") behind
+which further actions are hidden.
+
+- The secondary button basically toggles the context menu.
+- An individual event handler can be stored for the primary button; if this is not done, it will also toggle the context menu.
+
+## Construction
+
+### Code
+
+```html
+<kol-split-button _label="Split-Button">Split-Button Popover</kol-split-button>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|---------------|-----------------------------------------------------------------------------------------------------|-------------------|
+| `click` | Element is clicked | `_value` property |
+| `onMouseDown` | A pointing device key is pressed while the pointer is inside the element | - |
+
+### Example
+
+<kol-split-button _label="Split-Button">
+Split button popover
+</kol-split-button>
+
+<Readme />
+
+<ExampleLink component="split-button" />
+
+## Live editor
+
+<LiveEditorCompact component="split-button" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/table-stateful.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/table-stateful.mdx
@@ -1,0 +1,212 @@
+---
+title: TableStateful
+description: Description, specification and examples for the TableStateful component.
+---
+
+import Readme from '/readmes/table-stateful/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+Synonyms: Data Table, Details List, Data Grid
+
+The **TableStateful** component is primarily used to clearly display datasets. It is designed in such a way that it automatically determines all values ​​dependent on the data and displays the table accordingly. These include, for example, the optional column sorting or pagination functions.
+
+<kol-indented-text _summary="Backend-seitige Pagination">
+For very large amounts of data, manual use of the TableStateless component is also possible. This means that the table is filled “manually” page by page. To do this, you can simply use a “own” pagination under the table using the pagination component instead of the table pagination. A possible sorting must also be implemented via the `onSort` events themselves. See <kol-link _href="table-stateless" _label="KolTableStateless" />.
+</kol-indented-text>
+
+## Construction
+
+The Table component is designed in such a way that the entire table structure does not have to be described in the markup itself. The component itself takes care of how exactly the table needs to be structured in a markup-specific manner in order to be barrier-free.
+
+Because the table component dynamically assembles the valid and accessible markup, the complex markup for the assistive systems can be taken away from the developer.
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|-------------------|----------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `selectionChange` | The selection of table rows has changed | Array of selected row objects or row object with single selection |
+| `settingsChange` | The table settings were changed by the user. | Object of type `TableSettings` |
+
+### Functionalities
+
+The Table component supports the following functionalities:
+
+- Table description using a **`label`** attribute.
+- Multi-line column headings in horizontal or vertical direction.
+- Sorting function for either horizontal and vertical orientation.
+- Different rendering function for the cells.
+- Pagination for the table.
+
+The Table component **does not** support the following functionalities:
+
+- Filtering the table is currently not provided within the table.
+- Selecting rows is currently not provided in the table.
+
+> However, both could be implemented using the render function.
+
+### Pagination
+
+A variety of additional properties to control pagination can optionally be passed via the **`_pagination`** attribute. The exact description of the options can be found on the page <kol-link _href="../pagination" _label="/docs/components/pagination" _label="Pagination"></kol-link>.
+
+#### KoliBriTableHeaders
+
+```ts
+{
+  horizontal: [
+    [
+      {
+        label: string,
+        key?: string,
+        colsSpan?: number,
+        rowSpan?: number,
+        useTdInsteadOfTh?: boolean,
+        render?: (data) => string,
+        compareFn?: (dataA, dataB) => number,
+      },
+      …
+    ],
+    …
+  ],
+  vertical: [
+    [
+      {
+        label: string,
+        key?: string,
+        colsSpan?: number,
+        rowSpan?: number,
+        useTdInsteadOfTh?: boolean,
+        render?: (data) => string,
+        compareFn?: (dataA, dataB) => number,
+      },
+      …
+    ],
+    …
+  ],
+};
+```
+
+### Code
+
+```html
+<kol-table-stateful
+	_label="Tabellenbeschreibung"
+	_headers='{"horizontal": [[{"label":"Montag","key":"montag"}]]}'
+	_pagination='[{"page":2}]'
+></kol-table-stateful>
+```
+
+### Example
+
+<kol-table-stateful _label="Nur Vertikal Header, Daten Vertikal, Pagination" _headers='{"horizontal":[[{"label":"Montag","key":"montag"}]]}' _data='[{"montag":"Zelle1"},{"montag":"Zelle2"}]' _pagination='{"page":2}'></kol-table-stateful>
+
+### Footer
+
+By using the **`_dataFoot_`** attribute, summary information or additional details can be displayed at the end of the table. The information is tied to the column definitions.
+
+### Example
+
+<kol-table-stateful _label="Nur Vertikal Header, Daten Vertikal, Pagination, DataFoot" _headers='{"horizontal":[[{"label":"Montag","key":"montag"}]]}' _data='[{"montag":"Zelle1"},{"montag":"Zelle2"}]' _dataFoot='[{"montag":"Ruhetag"}]' _pagination='{"page":2}'></kol-table-stateful>
+
+## Usage
+
+### Sorting
+
+- You can define a sorting function for each header.
+- Exactly one or no sorting function is activated.
+- **Multi-Sort Functionality**: If the multi-sort option (`_allowMultiSort`) is enabled, the user can sort multiple columns at the same time. By default, this feature is disabled and only one column can be sorted at a time. The sorting switches between ascending, descending and no sorting. If multi-sort is disabled, the previous column will be unsorted whenever a new column is sorted.
+- Currently it is not supported that with two-dimensional headers, the headers of the other header page are also sorted. When requesting sorting, we recommend using only one header dimension (either horizontal or vertical).
+
+### Render function
+
+Render functions are defined as part of the table headers. See the KoliBriTableHeaders section. If there are both horizontal and vertical headers, the render function must be defined for the _horizontal_ headers. If there are only vertical headers, the render functions can be defined there.
+
+The `render` function can be used in various ways as follows.
+All methods are also demonstrated in this example: [render-cell.tsx](https://github.com/public-ui/kolibri/blob/23ebb42d1ce3c8d1e4c74a5c7972842d5e4203fe/packages/samples/react/src/components/table/render-cell.tsx#L34)
+
+1. String return value:
+
+```tsx
+{
+  render: (_el, cell) => `Index: ${cell.label}`,
+}
+```
+
+2. Fill node with textContent
+
+```tsx
+{
+  render: (el, cell) => {
+    el.textContent = `Index: ${cell.label}`;
+  },
+}
+```
+
+3. Fill node with innerHTML - ⚠️ Make sure to sanitize values ​​to avoid XXS.
+
+```tsx
+{
+  render: (el, cell) => {
+    el.innerHTML = `<strong>${cell.label}</strong>`;
+  },
+}
+```
+
+4. Use React render function
+
+```tsx
+import { createReactRenderElement } from '@public-ui/react-v19';
+{
+  render: (el) => {
+    getRoot(createReactRenderElement(el)).render(
+      <div>
+        <KolInputText _label="Input" />
+        <KolButton _label="Save" />
+      </div>,
+    );
+  },
+}
+```
+
+### Settings
+
+Table settings (`_table-settings`) are passed through to the kol-table-stateless component. See <kol-link _href="table-stateless#settings" _label="kol-table-stateless documentation" />.
+
+<!--### Best practices
+
+### Use cases-->
+
+## Accessibility
+
+The Table component adds numerous attribute definitions to the table markup to best support screen readers.
+
+The following attributes are currently managed by the component: `role`, `scope` and `aria-\*`.
+
+This means, for example, that either the `colheader` or `rowheader` role is automatically set for the column headings. In addition, the scope is set to either `col`/`colgroup` or `row`/`rowgroup`. Similar to these automatisms, the `aria-\*` attributes are also set depending on relevance.
+
+Why the table has a **tab index** is described on the following website: <kol-link _href="" _label=""></kol-link>https://dequeuniversity.com/rules/axe/3.5/scrollable-region-focusable
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/WAI/tutorials/tables/" _target="_blank"></kol-link>
+- <kol-link _href="https://www.sperrfreies-webdesign.de/knowhow/datentafeln/scope.html" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/de/docs/Web/Accessibility/ARIA/ARIA_Live_Regions" _target="_blank"></kol-link>
+- <kol-link _href="https://tollwerk.de/projekte/tipps-technik-inklusiv-barrierfrei/aria-live-regionen" _target="_blank"></kol-link>
+- <kol-link _href="https://www.sperrfreies-webdesign.de/knowhow/live-regions/attribute.html" _target="_blank"></kol-link>
+- <kol-link _href="https://www.digitala11y.com/aria-sort-properties/" _target="_blank"></kol-link>
+- <kol-link _href="https://dequeuniversity.com/library/aria/table-sortable" _target="_blank"></kol-link>
+- <kol-link _href="https://www.maxability.co.in/2016/06/07/aria-sort-property/" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaSort" _target="_blank"></kol-link>
+- <kol-link _href="https://tollwerk.de/projekte/tipps-technik-inklusiv-barrierfrei/aria-live-regionen" _target="_blank"></kol-link>
+- <kol-link _href="https://stackoverflow.com/questions/1312236/" _target="_blank"></kol-link>
+- <kol-link _href="https://dequeuniversity.com/rules/axe/3.5/scrollable-region-focusable" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="table-stateful" />
+
+## Live editor
+
+<LiveEditorCompact component="table-stateful" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/table-stateless.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/table-stateless.mdx
@@ -1,0 +1,137 @@
+---
+title: TableStateless
+description: Description, specification and examples for the TableStateless component.
+---
+
+import Readme from '/readmes/table-stateless/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+Synonyms: Data Table, Details List, Data Grid
+
+The **TableStateless** component is responsible for purely displaying the KoliBri table. For a table component that can automatically sort and paginate with the data provided, see <kol-link _href="table-stateful" _label="KolTableStateful" />.
+
+TableStateless is particularly useful for larger amounts of data if it is not practical to deliver the entire amount of data to the browser for filtering and sorting.
+
+## Direction of data playback
+
+The KolTableStateless component provides a flexible table implementation that supports bi-directional data playback. The direction of data playback is determined by the header configuration:
+
+- Horizontal Headers (Default): The data is rendered from top to bottom when keys are present in the horizontal headers. Each column represents a key, and the rows represent individual data entries.
+- Vertical headers: The data is presented from left to right when the keys are present in the vertical headers and not present in the horizontal headers. Each row represents a key, and columns represent individual data entries.
+
+The display direction is automatically determined by examining the header cells:
+
+- If horizontal headers contain keys, horizontal representation is used.
+- If only vertical headers contain keys, renders vertically.
+- If no headers contain keys, horizontal rendering is used by default.
+
+
+## Selection
+
+The “selection mode” of the component can be activated and controlled via the `_selection` property. If `_selection` is defined, each line receives a checkbox that can be used to select or deselect the line.
+
+- **label**: Function that is called for each line and returns a label for the checkbox.
+- **selectedKeys**: Array of strings containing the key properties of the selected lines.
+- **disabledKeys**: Array of strings containing the key properties of the disabled lines. For lines that occur in `disabledKeys`, the checkbox or radio button is deactivated.
+- **keyPropertyName**: Property referenced by `selectedKeys` and `disabledKeys`. Default value: `id`.
+
+```ts
+const data = [
+	{ id: '1001', name: 'Marianne Musterfrau' },
+	{ id: '1002', name: 'Max Mustermann' },
+];
+const selection: KoliBriTableSelection = {
+	label: (row: KoliBriTableDataType) => `Selection for ${row.name}`,
+  selectedKeys: ['1002'],
+  disabledKeys: ['1001'],
+  keyPropertyName: 'id',
+};
+```
+
+## Settings
+
+Tables automatically have a settings menu that allows users to:
+
+* Show and hide columns
+* Adjust column widths
+* Change column order
+
+By default, all horizontal table columns are taken into account.
+
+The _tableSettings property can be used to load predefined or already saved table configurations. These overwrite the default values, and only the columns listed there are then displayed in the menu.
+
+Example:
+
+```jsx
+<KolTableStateful
+	_tableSettings={{
+		columns: [
+			{ key: 'columnA', visible: false, label: 'Column A', position: 2 },
+			{ key: 'columnB', visible: true, label: 'Column B', position: 1, width: 20 },
+			{ key: 'columnC', visible: true, label: 'Column C', position: 0, width: 45 },
+		],
+	}}
+	// ...
+/>
+```
+
+If users change the settings, they are automatically transferred to the table view and a <nobr>`settingsChange`</nobr> DOM event is triggered (see Events).
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|-------------------|--------------------------------------------------------|----------------------------------------------------------------------|
+| `sort` | The sorting has changed | Object of type `SortEventPayload` with `key` and `currentSortDirection` |
+| `selectionChange` | The selection of table rows has changed | Array of selected IDs or selected ID for single selection |
+| `settingsChange` | The table settings were changed by the user. | Object of type `TableSettings` |
+
+## Example
+
+```jsx
+<KolTableStateless
+  _label="Table for demonstration purposes"
+  _headerCells={{
+    horizontal: [
+      [
+        { key: 'value', label: 'Value', sortDirection: 'ASC' },
+      ],
+    ],
+  }}
+  _data={DATA}
+  _selection={{
+    label: (row: KoliBriTableDataType) => `Selection for ${row.name}`,
+    selectedKeys: ['1002'],
+    keyPropertyName: 'id',
+  }}
+  _on={{
+    /**
+     * @param {MouseEvent} _
+     * @param {SortEventPayload} payload
+     * @param {string} payload.key
+     * @param {KoliBriSortDirection} payload.currentSortDirection
+     */
+    onSort: (_: MouseEvent, payload: SortEventPayload) => {
+      /* Perform sort, update `DATA` and headers `sortDirection` */
+    },
+
+    /**
+     * @param {Event} _
+     * @param {string[]} selection - Array of selected keys
+     */
+    onSelectionChange: (_: Event, selection: string[]) => {
+      /* Update selection.selectedKeys state */
+    }
+  }}
+/>
+```
+
+<Readme />
+
+<ExampleLink component="table-stateless" />
+
+## Live editor
+
+<LiveEditorCompact component="table-stateless" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/tabs.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/tabs.mdx
@@ -1,0 +1,126 @@
+---
+title: Tabs
+description: Description, specification and examples for the Tabs component.
+---
+
+import Readme from '/readmes/tabs/readme.md';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Tabs
+
+Synonyms: Navigation, Nav
+
+The **Tabs** component is used to organize and navigate between related content on the same page. Tabs make it easier for users to organize large amounts of content. Tabs are arranged in tab bars called tab groups, where the tab label gives users an indication of what content will be displayed when the tab is selected.
+
+## Construction
+
+After loading the component, the first tab on the left will automatically be visually highlighted as **_active_**. Each tab takes on the status **_active_** after being clicked. The status **_active_** can also be set manually to the index of the registry card using the **`_selected`** attribute.
+The individual contents of the tab are noted in a separate `HTMLDivElement` as `<div>Contents of the tab</div>` within `<kol-tabs></kol-tabs>`.
+
+The data in the **`_tabs`** attribute is assigned to the div elements automatically.
+
+### Code
+
+```html
+<kol-tabs _selected="0" _tabs='[{"_label":"Tab 1","_icons":"codicon codicon-home"},{"_label":"Tab 2", "_on": {"onClose": true}},{"_label":"Tab 3"}]'>
+	<div>Inhalt von Tab 1</div>
+	<div>Inhalt von Tab 2</div>
+	<div>Inhalt von Tab 3</div>
+</kol-tabs>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|--------------------------------|----------------------------|
+| `select` | Tab has been selected | Index of the selected tab |
+| `create` | Create button was clicked | - |
+
+### Example
+
+<kol-tabs _selected="0" _tabs='[{"_label":"Tab 1","_icons":"codicon codicon-home"},{"_label":"Tab 2", "_on": {"onClose": true}},{"_label":"Tab 3"}]'>
+	<div>Inhalt von Tab 1</div>
+	<div>Inhalt von Tab 2</div>
+	<div>Inhalt von Tab 3</div>
+</kol-tabs>
+
+## Usage
+
+### Definition of tabs
+
+The data for the tabs can be passed to the **`_tabs`** attribute as objects or a JSON string.
+
+```json
+[{ "_label": "Tab 1", "_icons": "codicon codicon-home" }, { "_label": "Tab 2", "_on": { "onClose": true } }, { "_label": "Tab 3" }]
+```
+
+### Disable tab
+
+To disable a tab, use the **`_disabled`** attribute.
+
+### Create button
+
+The attribute **`_has-create-button`** can be used to activate an additional button in the tab navigation. This button appears at the end of the tab bar and allows users to dynamically add new tabs.
+
+#### Code
+
+```html
+<kol-tabs _tabs='[{"_label":"Tab 1"},{"_label":"Tab 2"}]' _has-create-button>
+	<div>Inhalt von Tab 1</div>
+	<div>Inhalt von Tab 2</div>
+</kol-tabs>
+```
+
+<kol-link _href="https://develop--kolibri-public-ui.netlify.app/#/tabs/create-button" _target="_blank" _label="Beispiel in der Sample App"></kol-link>
+
+### Best practices
+
+- Use tabs to organize and group related content so users don't have to leave the page.
+- Tabs should be positioned in a single, scrollable (if necessary) line above the content they relate to.
+- Use the tab label to clearly and concisely describe the contents of that tab and to distinguish between the different sections.
+- Don't use tabs to create a sequence or history of content that you want the user to read in a specific order.
+- Do not use tabs to compare content (e.g. different specifications).
+- Consider the number of tabs you include in the tab group. If you feel like the number is getting too large, consider breaking up the content further or using a different navigation pattern/component.
+
+### Use cases
+
+- Using tabs you can, for example, divide services or benefits into different categories.
+- Use tabs to organize user profiles into different sections (e.g. personal information, appointments, active services).
+- Use tabs to divide FAQs into different categories.
+
+## Accessibility
+
+### Keyboard controls
+
+When you jump to them using the **Tab key**, selected tabs are surrounded by a clear focus frame. The individual tabs can be scrolled through using the **left** and **right** arrow keys.
+
+After opening a tab, you can use the **Tab key** to switch from the header to the content area of ​​the tab.
+
+Regardless of whether the tab switches are located at the top, right, bottom or left, the keyboard controls remain the same. The background is that the layout plays no role when using a screen reader. A different arrow key control due to the layout arrangement would therefore not correspond to the usual W3C operating concept.
+
+The implementation of the keyboard control was based on the W3C examples.
+
+The focus here is always on the impaired user. In order to navigate as efficiently as possible across the entire page/application, only 1 switch from the Tab series can be focused. Once the user is on the tab navigation itself, the arrow keys are used to switch between the tabs themselves.
+
+| button | Function |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses on the first active tab. Existing close icons can be accessed with the Tab key. |
+| `Arrow keys (left \| right)` | Switches between tabs.                                                                             |
+
+## Links and references
+
+- <kol-link _href="https://www.w3.org/WAI/ARIA/apg/example-index/tabs/tabs-manual.html" _target="_blank"></kol-link>
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role" _target="_blank"></kol-link>
+- <kol-link _href="https://dequeuniversity.com/library/aria/tabpanel" _target="_blank"></kol-link>
+- <kol-link _href="https://design-system.service.gov.uk/components/tabs/" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="tabs" />
+
+## Live editor
+
+<LiveEditorCompact component="tabs" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/textarea.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/textarea.mdx
@@ -1,0 +1,168 @@
+---
+title: Textarea
+description: Description, specification and examples for the Textarea component.
+---
+
+import Readme from '/readmes/textarea/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Textarea
+
+The **Textarea** component provides a larger input field for content. In contrast to the <kol-link _href="../components/input-text" _label="/docs/components/input-text" _label="InputText"></kol-link>, extensive content can also be entered here, which can also contain line breaks.
+
+## Construction
+
+### Code
+
+```html
+<kol-textarea
+  _label="Beschreibung"
+  _resize="none"
+  _rows="5"
+  _value="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+    magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+    gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
+    elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+    et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
+    sit amet."
+></kol-textarea>
+```
+
+### Events
+
+For the handling of events or callbacks, see <kol-link _label="Events" _href="../concepts/events" />.
+
+| Event | trigger | Value |
+|----------|----------------------------------|---------------------------------|
+| `click` | Input field is clicked | - |
+| `focus` | Input field is focused | - |
+| `blur` | Input field loses focus | - |
+| `input` | Value is changed by entering | Current value of the input field |
+| `change` | Entry has been completed | Current value of the input field |
+
+### Example
+
+```html
+<kol-textarea
+  _label="Beschreibung"
+  _resize="none"
+  _rows="5"
+  _value="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.">
+</kol-textarea>
+```
+## Usage
+
+Use the **Textarea** component if the entry of larger amounts of text is required, e.g. when entering a request within a form.
+The height of the text area in lines can be determined using the **`_rows`** attribute.
+The **`_resize`** attribute can also be used to specify whether and in which direction the text area can be enlarged. The value **`none`** locks the text area against size changes.
+
+<!--### Best practices
+
+### Use cases-->
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| -------------- | ------------------------------------------------------------------------------- |
+| `Tab` | Focuses the text area.                                                        |
+| `arrow keys` | Can be used to navigate the content of the focused text area. |
+
+
+## Character limit and character counter
+
+With the three attributes `_max-length`, `_max-length-behavior` and `_has-counter`, the input length can be flexibly limited and at the same time provide visual feedback.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| ---------------------- | ------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_has-counter` | `boolean` | `false` | Global switch for the character counter. Only if this attribute is **set (= true)** will a counter be output.                                                                                                                                                           |
+| `_max-length` | `number` | — | Maximum number of characters allowed. Effective only if `_has-counter` is active.                                                                                                                                                                                                              |
+| `_max-length-behavior` | `"hard" \| "soft"` | `"hard"` | Specifies how the limit is handled **if** `_max-length` is set:<br />- **hard**: Additionally sets the native `maxlength` attribute and prevents further input.<br />- **soft**: Allows further input; the counter shows remaining or exceeded characters. |
+
+### Output variants
+
+| case | `_has-counter` | `_max-length` | `_max-length-behavior` | Visible text |
+| ---: | --------------------- | ------------- | ---------------------- | -------------------------------------------------------- |
+| 1 | *(empty)* or `false` | — | — | — (no counter) |
+| 2 | `true` | *(empty)* | — | `n character` |
+| 3 | `true` | 5 | *(empty)* or `hard` | `n/5 characters` |
+| 4 | `true` | 5 | `soft` | `3 characters still available`<br />*(or `3 characters too many`)* |
+
+> If `_max-length-behavior="soft"` is used, **the native `maxlength` attribute is *not* set** - so the input field is not hard-limited.
+
+### Accessibility
+
+* The counter updates with a **500ms** delay so that screen reader events are concentrated and do not interrupt typing.
+* For screen readers, a hidden text that is only visible to assistive technologies is also displayed, such as:
+*“You can enter up to 10 characters.”*
+
+### Examples
+
+```html
+<!-- Nur Zähler -->
+<kol-textarea _label="Beschreibung" _has-counter></kol-textarea>
+
+<!-- Harte Begrenzung auf 5 Zeichen -->
+<kol-textarea _label="Beschreibung" _has-counter _max-length="5"></kol-textarea>
+
+<!-- Weiche Begrenzung auf 5 Zeichen -->
+<kol-textarea
+  _label="Beschreibung"
+  _has-counter
+  _max-length="5"
+  _max-length-behavior="soft">
+</kol-textarea>
+```
+
+### Summary
+
+* Without `_has-counter` there is **never** a counter.
+* With `_has-counter` **and without** `_max-length` only the currently entered number of characters is displayed.
+* With `_has-counter` **and** `_max-length`, `_max-length-behavior` determines whether the limit is implemented hard (`hard`) or softly (`soft`).
+
+## Links and references
+
+- <kol-link _href="https://medium.com/@gavyn/til-autofocus-inputs-are-an-accessibility-problem-32ced60c3109" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="textarea" />
+
+## Live editor
+
+<LiveEditorCompact component="textarea" />
+
+## Examples
+
+### Simply
+
+<Configurator component="textarea" sample="basic" />
+
+### Automatic line adjustment
+
+<Configurator component="textarea" sample="adjust-height" />
+
+### Disabled
+
+<Configurator component="textarea" sample="disabled" />
+
+### Placeholders
+
+<Configurator component="textarea" sample="placeholder" />
+
+### Readonly
+
+<Configurator component="textarea" sample="readonly" />
+
+### Resizable text area
+
+<Configurator component="textarea" sample="resize" />
+
+### Line length
+
+<Configurator component="textarea" sample="rows" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/toaster.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/toaster.mdx
@@ -1,11 +1,6 @@
 ---
 title: Toaster
-description: Beschreibung, Spezifikation und Beispiele für die Toast-Komponente.
-tags:
-  - Toast
-  - Beschreibung
-  - Spezifikation
-  - Beispiele
+description: Description, specification and examples for the Toast component.
 ---
 
 import Readme from '/readmes/toaster/readme.md';
@@ -13,10 +8,10 @@ import { ExampleLink } from '@site/src/components/ExampleLink';
 
 # Toaster
 
-Synonyms: Notification, Snackbar
+Synonyms: notification, snack bar
 
-With the **Toast** service, you provide visual feedback to users. It is displayed at the top of the browser window
- until it is closed. If multiple toasts are opened without the previous ones being closed, they are displayed one below the other.
+With the **Toast** service you give visual feedback to the users. It will appear at the top of the browser window
+until it is closed. If several toasts are opened without the previous ones being closed, they will be displayed one below the other.
 
 ## Construction
 
@@ -44,20 +39,20 @@ toaster.enqueue({
 ### Other service methods
 
 - `closeAll`: Closes all toasts
-- `dispose`: Removes the Toast container. The Toaster instance can no longer be used.
+- `dispose`: Removes the toast container. The Toaster instance can no longer be used.
 
 ## Usage
 
 ### Headline
 
-Use the **`_label`** attribute to specify the toast's title.
+Use the **`_label`** attribute to determine the heading of the toast.
 
-### Content
+### Contents
 
-Use the **`_description`** attribute to specify the text content of the toast.
+Use the **`_description`** attribute to determine the text content of the toast.
 
-As an alternative to the static description, you can define your own render function using the **`_render`** attribute. This is called with a reference
-to the HTML element of the Toast component. An object is also passed that provides a `close`-function for closing the Toast.
+As an alternative to the static description, you can define your own render function using the **`_render`** attribute. This is provided with a reference to
+HTMLElement of the Toast component called. An object is also passed that provides a `close` function to close the toast.
 
 ```ts
 const closeToast = toaster.enqueue({
@@ -70,25 +65,25 @@ const closeToast = toaster.enqueue({
 	},
 });
 
-/* Optional: Close Toast again with `closeToast()` */
+/* Optional: Toast wieder schließen mit `closeToast()` */
 ```
 
 ### Toast display option
 
-In KoliBri we distinguish three levels:  
+In KoliBri we differentiate between three levels:
 
-- **`_type`** → defines the **semantic meaning** or logical function of a component.  
-  *Example*: For `kol-button`: `"button" | "submit" | "reset"`, for `kol-alert`: `"info" | "success" | "warning" | "error"`.  
+- **`_type`** → defines the **semantic meaning** or logical function of a component.
+*Example*: For `kol-button`: `"button" | "submit" | "reset"`, at `kol-alert`: `"info" | "success" | "warning" | "error"`.
 
-- **`_variant`** → controls the **visual appearance**, e.g. `"primary"`, `"secondary"`, `"ghost"`.  
+- **`_variant`** → controls the **visual appearance**, e.g. E.g. `"primary"`, `"secondary"`, `"ghost"`.
 
-- **`_behavior`** → determines the **interaction behavior** of the component.  
-  *Example*: For `kol-tabs`: `"select-automatic"` vs. `"select-manual"`.  
+- **`_behavior`** → determines the **interaction behavior** of the component.
+*Example*: For `kol-tabs`: `"select-automatic"` vs. `"select-manual"`.
 
-👉 In short:  
-- `_type` = meaning & logic  
-- `_variant` = look & styling  
-- `_behavior` = interaction & behavior   
+👉 In short:
+- `_type` = meaning & logic
+- `_variant` = Look & Styling
+- `_behavior` = interaction & behavior
 
 <Readme />
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/toolbar.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/toolbar.mdx
@@ -1,0 +1,54 @@
+---
+title: Toolbar
+description: Description and specification for the toolbar component.
+---
+
+import Readme from '/readmes/toolbar/readme.md';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Toolbar
+
+The **Toolbar** component is a collection of commonly used button and link controls summarized in a compact visual form. The toolbar is typically a subset of functions found in a menu bar to reduce user effort.
+
+```html
+<kol-toolbar _label="Label" _items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link",  type="link"}]'> </kol-toolbar>
+```
+
+### Example
+
+<kol-toolbar
+_label="Label"
+_items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link", type="link"}]'>
+</kol-toolbar>
+
+## Usage
+
+Use the **Toolbar** component if you want to enable navigation of various buttons and links, e.g. to format the content of a text area.
+The **`aria-label`** can be set using the **`_label`** attribute.
+The individual functions are set in the toolbar using the **`_items`** attribute.
+The **`tabIndex`** is controlled by the **Toolbar** component. The default is always the first active element in the **Toolbar**.
+
+### Supported **Toolbar** components
+
+- Link
+- button
+
+The **Toolbar** component is told whether it is a **Link** or **Button** component using the **`type`** attribute.
+
+## Accessibility
+
+### Keyboard controls
+
+| button | Function |
+| -------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `Tab` | First tab focuses on the toolbar. Second the first active element and third restores the default. |
+| `arrow keys` | Can be used to navigate elements in the focused toolbar.                            |
+
+## Links and references
+
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/toolbar_role" _target="_blank"></kol-link>
+- <kol-link _href="https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="toolbar" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/tooltip.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/tooltip.mdx
@@ -1,0 +1,47 @@
+---
+title: Tooltip
+description: Description and specification for the tooltip component.
+---
+
+# Tooltip
+
+Synonyms: Inline dialog, popover
+
+<kol-alert _type="info" _variant="card">Die **Tooltip**-Komponente wird innerhalb von KoliBri verwendet und ist nicht dafür vorgesehen in der Anwendungsentwicklung verwendet zu werden. Denn der Tooltip ist nur dann wirklich barrierefrei, wenn von einem Referenzelement auf das Tooltip verwiesen wird.</kol-alert>
+
+The **Tooltip** component implements the counterpart of the `Aria label`. It is therefore explicitly intended only to show the label of an element to the user without a screen reader.
+
+An open tooltip can be closed with the 'Escape' key in order to make any overlaid page information visible again.
+
+**Note:** In order for the tooltip to align correctly, the reference element must not have `display: inline`.
+
+## Accessibility
+
+The tooltip component is displayed when the focus is on or when the mouse is moved over the reference element and is intended exclusively for the sighted user to be able to read the label (Aria label) without a screen reader. The text of the tooltip cannot be accessed with the keyboard and is also hidden from screen readers using Aria-Hidden.
+
+<kol-alert _type="info">
+From an accessibility testing perspective, tooltips can be ignored as long as development also ensures that the tooltip text is read out in the same way by the screen reader.
+</kol-alert>
+
+## Width
+
+The width of the tooltip usually depends on its content.
+To configure the width of a tooltip, a [CSS-Custom-Property](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) can be defined on the surrounding container as follows:
+
+```css
+.container {
+  --kol-tooltip-width': '40rem';
+}
+```
+
+## Known issues
+
+When using CSS `contain: layout` within the tooltip element, the positioning may be incorrect. The cause is a <kol-link _href="https://github.com/floating-ui/floating-ui/issues/3067" _target="_blank">Bug in floating-ui</kol-link>, which was documented in <kol-link _href="https://github.com/public-ui/kolibri/pull/8062" _target="_blank">PR #8062</kol-link>.
+
+**Workaround:** Do not put `contain: layout` directly on the tooltip. Instead, the property should only be used where container queries are needed.
+
+**Outlook:** In the long term, the native <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/CSS/anchor" _target="_blank">`anchor()` function</kol-link> could be used instead of `floating-ui`. This is currently only available in Chrome; `floating-ui` is still required for Firefox and Safari.
+
+## Links and references
+
+- <kol-link _href="https://tollwerk.de/projekte/tipps-technik-inklusiv-barrierfrei/title-tooltips-toggletips" _target="_blank"></kol-link>

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/tree-item.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/tree-item.mdx
@@ -1,0 +1,11 @@
+---
+title: Tree Item
+description: Description, specification and examples for the Tree component.
+---
+import Readme from '/readmes/tree-item/readme.md';
+
+# Tree Item
+
+Further information about the tree can be found on the <kol-link _href="../components/tree" _label="Tree component page"></kol-link>.
+
+<Readme />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/tree.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/tree.mdx
@@ -1,0 +1,82 @@
+---
+title: Tree
+description: Description, specification and examples for the Tree component.
+---
+
+import Readme from '/readmes/tree/readme.md';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+#Tree
+
+Synonyms: cunning, navigation
+
+The **Tree** component represents a hierarchical list in which each element can contain child entries. Elements with child elements can be collapsed or expanded to show or hide the child level.
+
+### Code
+
+```html
+<kol-tree _label="Sitemap">
+	<kol-tree-item _label="Home" _href="#" _active></kol-tree-item>
+	<kol-tree-item _label="Page 1" _href="#" _open>
+		<kol-tree-item _label="Subpage 1" _href="#" _open>
+			<kol-tree-item _label="Product 1" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 2" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 3" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 4" _href="#"></kol-tree-item>
+		</kol-tree-item>
+		<kol-tree-item _label="Subpage 2" _href="#"></kol-tree-item>
+		<kol-tree-item _label="Subpage 3" _href="#"></kol-tree-item>
+		<kol-tree-item _label="Subpage 4" _href="#"></kol-tree-item>
+	</kol-tree-item>
+	<kol-tree-item _label="Page 2" _href="#"></kol-tree-item>
+</kol-tree>
+```
+
+### Example
+
+<kol-tree _label="Sitemap">
+	<kol-tree-item _label="Home" _href="#" _active></kol-tree-item>
+	<kol-tree-item _label="Page 1" _href="#" _open>
+		<kol-tree-item _label="Subpage 1" _href="#" _open>
+			<kol-tree-item _label="Product 1" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 2" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 3" _href="#"></kol-tree-item>
+			<kol-tree-item _label="Product 4" _href="#"></kol-tree-item>
+		</kol-tree-item>
+		<kol-tree-item _label="Subpage 2" _href="#"></kol-tree-item>
+		<kol-tree-item _label="Subpage 3" _href="#"></kol-tree-item>
+		<kol-tree-item _label="Subpage 4" _href="#"></kol-tree-item>
+	</kol-tree-item>
+	<kol-tree-item _label="Page 2" _href="#"></kol-tree-item>
+</kol-tree>
+
+## Usage
+
+The Tree component is used to visually display complex, hierarchically structured data and make it user-friendly and navigable. It allows users to move efficiently through nested structures while providing a clear overview of the relationships between parent and child elements.
+
+Typical areas of application include: E.g. navigation bars, organizational structures, file directories or product catalogs – wherever content needs to be displayed in a structured and multi-level manner.
+
+Each navigation point is labeled using the `_label` attribute and can optionally be linked to a destination via `_href`. The `_active` attribute can be used to mark an element as currently active, while `_open` controls whether an element is opened when initially loaded.
+
+### Keyboard controls
+
+| button | Function |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Tab` | Focuses the Tree component so that it can be operated using the keyboard.                                                                                                                                                  |
+| `↑ / ↓` | Navigates between visible elements on the same layer.                                                                                                                                                                  |
+| `→` | Opens the submenu of the currently focused item (if any).                                                                                                                                                    |
+| `←` | Closes the submenu (if open) or moves focus to the parent item.                                                                                                                             |
+| `Enter` | Activates the currently focused element. If a `_href` attribute is present, navigation to the destination occurs.                                                                                                         |
+| `Pos1` | Focuses on the first element of the Tree component.                                                                                                                                                                             |
+| `end` | Focuses on the last element of the Tree component.                                                                                                                                                                            |
+| `*` | Opens all closed sibling elements on the currently focused layer.                                                                                                                                             |
+| Alphanumeric | Entering a letter will focus the next element whose `_label` starts with that character. Pressing the same letter repeatedly will jump to the next appropriate element. |
+
+## Links and references
+
+- <kol-link _href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tree_role" _target="_blank"></kol-link>
+- <kol-link _href="https://www.w3.org/WAI/ARIA/apg/patterns/treeview/" _target="_blank"></kol-link>
+
+<Readme />
+
+<ExampleLink component="tree" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/version.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/version.mdx
@@ -1,0 +1,46 @@
+---
+title: Version
+description: Description, specification and examples for the Version component.
+---
+
+import Readme from '/readmes/version/readme.md';
+import { Configurator } from '@site/src/components/Configurator';
+import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
+import { ExampleLink } from '@site/src/components/ExampleLink';
+
+# Version
+
+The **Version** component displays short content on a colored background. The **Version** component is closely related to the **Tag** component, but only provides one attribute for configuration. It is optimized for specifying versions of a page, for example.
+
+## Construction
+
+### Code
+
+```html
+<div>
+	<kol-version _label="1.44.0"></kol-version>
+</div>
+```
+
+### Example
+
+<kol-version _label="1.44.0"></kol-version>
+
+## Usage
+
+The attribute **`_label`** is available for configuration and accepts any text preceded by a `v` in the component.
+
+The **version** is output as an **_inline element_** by default.
+
+<Readme />
+
+<ExampleLink component="version" />
+
+## Live editor
+
+<LiveEditorCompact component="version" />
+
+## Examples
+
+<Configurator component="version" sample="basic" />
+<Configurator component="version" sample="context" />


### PR DESCRIPTION
## Summary
- add English i18n translations for all component documentation pages under `30-components`
- update the English components index and align documentation imports to use the shared readme assets

## Testing
- pnpm run lint
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694264a83920832ba532e895a45b53ae)