### PR TITLE
fix: update rimraf patterns to handle directory paths correctly

### DIFF
--- a/scripts/autogen.doc.js
+++ b/scripts/autogen.doc.js
@@ -120,7 +120,9 @@ const mkDirs = (dirs, index = 0) => {
 	}
 };
 
-rimraf([...DOC_FOLDERS, '**/*.md'].join('/')).then(() => {
+const rimrafPatterns = DOC_FOLDERS.map((folder) => `${folder.replace(/\\/g, '/')}/**/*.md`);
+
+rimraf(rimrafPatterns, { glob: true }).then(() => {
 	README_PATHS.forEach((readmePath) => {
 		const name = path.basename(readmePath).replace(/\..+/g, '');
 		const folders = [...DOC_FOLDERS, name];


### PR DESCRIPTION
This pull request updates the logic for removing markdown files in the documentation generation script. Instead of deleting all markdown files using a single glob pattern, it now constructs explicit glob patterns for each documentation folder, improving reliability and compatibility.

**Build & Cleanup Improvements:**

* [`scripts/autogen.doc.js`](diffhunk://#diff-92aaad8f63fbdaac6794c2e8b508b62937b428c8c9bc711c768f235e862d116dL123-R125): Changed the `rimraf` call to use an array of glob patterns for each documentation folder, ensuring all markdown files (`**/*.md`) are correctly targeted and deleted. Also enabled globbing explicitly with the `{ glob: true }` option.