### PR TITLE
feat: Update theming descriptions in German and English to theme template repository

### DIFF
--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -330,11 +330,11 @@
 	"custom.homepage-message-part-2": {
 		"message": "Open Source zur Wiederverwendung und Weiterentwicklung freigegeben."
 	},
-	"custom.designer-short-description-part-1": {
-		"message": "Die semantisch barrierefreien Web Components können nahtlos in anderen Komponenten-Bibliotheken oder Design Systemen wiederverwendet werden. Mittels des"
+	"custom.theme-template-short-description-part-1": {
+		"message": "Vorgegebene Styleguides lassen sich mit KoliBri leicht umsetzen. Das"
 	},
-	"custom.designer-short-description-part-2": {
-		"message": "können die Komponenten an beliebige Styleguides oder Designs angepasst werden."
+	"custom.theme-template-short-description-part-2": {
+		"message": "liefert die technische Grundlage und ein SCSS-basiertes Setup, um schnell ein eigenes Theme zu implementieren."
 	},
 	"custom.developer-short-description": {
 		"message": "Die robusten Web Components (Shadow-Root) lassen sich in allen webbasierten Projekten wiederverwenden. Neben der direkten Verwendung der Web Components bieten wir auch Framework-Adapter für Angular, React, Preact und Solid an."

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -330,11 +330,11 @@
 	"custom.homepage-message-part-2": {
 		"message": "open source released for reuse and further development."
 	},
-	"custom.designer-short-description-part-1": {
-		"message": "The semantically accessible web components can be seamlessly reused in other component libraries or design systems. by means of"
+	"custom.theme-template-short-description-part-1": {
+		"message": "Predefined style guides can be easily implemented with KoliBri. The"
 	},
-	"custom.designer-short-description-part-2": {
-		"message": "the components can be adapted to any style guides or designs."
+	"custom.theme-template-short-description-part-2": {
+		"message": "provides the technical foundation and an SCSS-based setup to quickly implement your own theme."
 	},
 	"custom.developer-short-description": {
 		"message": "The robust web components (shadow root) can be reused in all web-based projects. In addition to using the Web Components directly, we also offer framework adapters for Angular, React, Preact and Solid."

--- a/src/components/HomepageFeatures.tsx
+++ b/src/components/HomepageFeatures.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { KolIcon, KolLink, KolLinkButton } from '@public-ui/react-v19';
 import { translate } from '@docusaurus/Translate';
 import Heading from '@theme/Heading';
-import { VERSION_ID } from '@site/src/shares/version';
 
 type FeatureItem = {
 	icon: string;
@@ -28,20 +27,24 @@ function Feature({ title, icon, description, button }: FeatureItem) {
 export default function HomepageFeatures(): ReactElement {
 	const FeatureList: FeatureItem[] = [
 		{
-			icon: 'codicon codicon-paintcan',
-			title: 'Designer',
+			icon: 'codicon codicon-symbol-color',
+			title: 'Theming',
 			description: (
 				<>
 					<p>
 						{translate({
-							id: 'custom.designer-short-description-part-1',
-							message:
-								'Die semantisch barrierefreien Web Components können nahtlos in anderen Komponenten-Bibliotheken oder Design Systemen wiederverwendet werden. Mittels des',
+							id: 'custom.theme-template-short-description-part-1',
+							message: 'Vorgegebene Styleguides lassen sich mit KoliBri leicht umsetzen. Das',
 						})}{' '}
-						<KolLink _href={`/${VERSION_ID}/designer`} _label="Designers" _target="designer" />{' '}
+						<KolLink
+							_href="https://github.com/public-ui/template-theme"
+							_label="Template Repository"
+							_target="template-theme"
+						/>{' '}
 						{translate({
-							id: 'custom.designer-short-description-part-2',
-							message: 'können die Komponenten an beliebige Styleguides oder Designs angepasst werden.',
+							id: 'custom.theme-template-short-description-part-2',
+							message:
+								'liefert die technische Grundlage und ein SCSS-basiertes Setup, um schnell ein eigenes Theme zu implementieren.',
 						})}
 					</p>
 				</>


### PR DESCRIPTION
This pull request updates the theming section on the homepage to better reflect the current approach, shifting the focus from "Designer" to "Theming" and referencing a new template repository. It also updates the corresponding translations in both German and English to match the new content.

**Homepage theming section update:**
- Changed the homepage feature title from "Designer" to "Theming", updated the icon, and revised the description to reference the new template repository and emphasize the SCSS-based setup for custom themes.

**Translation updates:**
- Updated German translations: replaced the "designer" short descriptions with new "theme-template" descriptions that align with the revised homepage content.
- Updated English translations: replaced the "designer" short descriptions with updated "theme-template" descriptions to match the new theming focus.…late repository