### PR TITLE
feat: ProgressPreview component

### DIFF
--- a/docs/30-components/progress.mdx
+++ b/docs/30-components/progress.mdx
@@ -8,9 +8,8 @@ tags:
   - Beispiele
 ---
 import Readme from '../../readmes/progress/readme.md';
-import { Configurator } from '@site/src/components/Configurator';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ProgressPreview from '@site/src/components/previews/components/Progress';
 
 # Progress
 
@@ -18,19 +17,12 @@ Die **Progress**-Komponente erzeugt einen Fortschrittsbalken, über den eine opt
 
 ## Konstruktion
 
-### Code
-
-```html
-<div>
-	<kol-progress _label="Fortschritt" _variant="bar" _max="100" _value="20"></kol-progress>
-	<kol-progress _label="Fortschritt" _variant="cycle" _max="100" _value="20"></kol-progress>
-</div>
-```
-
 ### Beispiel
 
-<kol-progress _label="Fortschritt" _variant="bar" _max="100" _value="20"></kol-progress>
-<kol-progress _label="Fortschritt" _variant="cycle" _max="100" _value="20"></kol-progress>
+<ProgressPreview 
+  codeCollapsable
+  codeCollapsed
+/>
 
 ## Verwendung
 
@@ -56,12 +48,6 @@ Verwenden Sie das Attribut **`_value`**, um den aktuellen Wert der Komponente zu
 
 <Readme />
 
-<ExampleLink component="progress" />
-
-## Live-Editor
-
-<LiveEditorCompact component="progress" />
-
 ## Beispiele
 
-<Configurator component="progress" sample="basic" />
+<ExampleLink component="progress" />

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -398,5 +398,8 @@
 	},
 	"preview.sourceCode.copyButton": {
 		"message": "Kopieren"
+	},
+	"preview.component.progress.label": {
+		"message": "Fortschritt"
 	}
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -398,5 +398,8 @@
 	},
 	"preview.sourceCode.copyButton": {
 		"message": "Copy"
+	},
+	"preview.component.progress.label": {
+		"message": "Progress"
 	}
 }

--- a/src/components/previews/components/Progress.tsx
+++ b/src/components/previews/components/Progress.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import Preview from '../Preview';
+import { BoundedNumberProperty, ClampedNumberProperty } from '../properties';
+import type { JSX } from '@public-ui/components';
+import { KolInputText, KolProgress, KolSelect } from '@public-ui/react-v19';
+import { translate } from '@docusaurus/Translate';
+
+const ProgressPreview: React.FC = (props: {
+    initialProps?: JSX.KolProgress;
+    visibleProperties?: (keyof JSX.KolProgress)[];
+    codeCollapsable?: boolean;
+}) => {
+    const defaultProps: JSX.KolProgress = {
+        _label: translate({
+            id: 'preview.component.progress.label',
+            message: 'Progress',
+        }),
+        _value: 20,
+        _max: 100,
+    };
+
+    const [maxValue, setMaxValue] = React.useState<number>(props.initialProps?._max ?? defaultProps._max);
+
+    const handleMaxChange = (newMax: number) => {
+        setMaxValue(newMax);
+    };
+
+    return (
+        <Preview<JSX.KolProgress>
+            propertyComponents={{
+                _label: <KolInputText _label="Label" />,
+                _value: (
+                    <ClampedNumberProperty
+                        label="Value"
+                        min={0}
+                        max={maxValue}
+                        _value={props.initialProps?._value ?? defaultProps._value}
+                    />
+                ),
+                _max: (
+                    <BoundedNumberProperty
+                        label="Max"
+                        min={1}
+                        max={1000}
+                        _value={maxValue}
+                        onBoundaryChange={handleMaxChange}
+                    />
+                ),
+                _unit: <KolInputText _label="Unit" />,
+                _variant: (
+                    <KolSelect
+                        _label="Variant"
+                        _options={[
+                            { label: 'Bar', value: 'bar' },
+                            { label: 'Cycle', value: 'cycle' },
+                        ]}
+                    />
+                ),
+            }}
+            initialProps={{ ...defaultProps, ...props.initialProps }}
+            componentName="KolProgress"
+            visibleProperties={props.visibleProperties}
+            codeCollapsable={props.codeCollapsable}
+            centerComponent
+        >
+            {(componentProps) => <KolProgress {...componentProps} />}
+        </Preview>
+    );
+};
+
+export default ProgressPreview;

--- a/src/components/previews/properties/BoundedNumberProperty.tsx
+++ b/src/components/previews/properties/BoundedNumberProperty.tsx
@@ -1,0 +1,35 @@
+import { KolInputNumber } from '@public-ui/react-v19';
+import React from 'react';
+
+const BoundedNumberProperty = (props: {
+    label: string;
+    min: number;
+    max: number;
+    _value?: number;
+    _on?: {
+        onInput?: (event: Event, value: unknown) => void;
+    };
+    onBoundaryChange?: (newBoundary: number) => void;
+}) => {
+    const handleInput = (event: Event, value: unknown) => {
+        const numValue = typeof value === 'number' ? value : parseFloat(value as string);
+        if (!isNaN(numValue) && numValue >= props.min && numValue <= props.max) {
+            props._on?.onInput?.(event, numValue);
+            props.onBoundaryChange?.(numValue);
+        }
+    };
+
+    return (
+        <KolInputNumber
+            _label={props.label}
+            _min={props.min}
+            _max={props.max}
+            _value={props._value}
+            _on={{
+                onInput: handleInput,
+            }}
+        />
+    );
+};
+
+export default BoundedNumberProperty;

--- a/src/components/previews/properties/ClampedNumberProperty.tsx
+++ b/src/components/previews/properties/ClampedNumberProperty.tsx
@@ -1,0 +1,46 @@
+import { KolInputNumber } from '@public-ui/react-v19';
+import React from 'react';
+
+const ClampedNumberProperty = (props: {
+    label: string;
+    min: number;
+    max: number;
+    _value?: number;
+    _on?: {
+        onInput?: (event: Event, value: unknown) => void;
+    };
+}) => {
+    const clampedValue = React.useMemo(
+        () => {
+            const newValue = props._value !== undefined
+                ? Math.max(props.min, Math.min(props._value, props.max))
+                : undefined;
+            if (newValue !== props._value) {
+                props._on?.onInput?.(new Event('input'), newValue);
+            }
+            return newValue;
+        },
+        [props._value, props.min, props.max]
+    );
+
+    return (
+        <KolInputNumber
+            _label={props.label}
+            _min={props.min}
+            _max={props.max}
+            _value={clampedValue}
+            _on={{
+                onInput: (event: Event, value: unknown) => {
+                    const numValue = typeof value === 'number' ? value : parseFloat(value as string);
+                    if (!isNaN(numValue)) {
+                        const clamped = Math.max(props.min, Math.min(numValue, props.max));
+                        props._on?.onInput?.(event, clamped);
+                    }
+                },
+            }}
+
+        />
+    );
+};
+
+export default ClampedNumberProperty;

--- a/src/components/previews/properties/index.ts
+++ b/src/components/previews/properties/index.ts
@@ -1,5 +1,7 @@
 export { default as AlignProperty } from './AlignProperty';
 export { default as BooleanProperty } from './BooleanProperty';
+export { default as BoundedNumberProperty } from './BoundedNumberProperty';
+export { default as ClampedNumberProperty } from './ClampedNumberProperty';
 export { default as IconProperty } from './IconProperty';
 export { default as MultiLineTextProperty } from './MultiLineText';
 export { default as ResizeProperty } from './ResizeProperty';


### PR DESCRIPTION
This pull request refactors the documentation and preview system for the Progress component, introducing a new interactive preview and improving localization support. The most significant changes are the replacement of static code examples with a live, configurable preview, the addition of new property controls for number inputs, and updates to translation files for better internationalization.

**Progress component preview and documentation improvements:**

* Replaced static code examples and usage sections in `docs/30-components/progress.mdx` with the new `ProgressPreview` interactive component, allowing users to experiment with component properties directly in the docs. [[1]](diffhunk://#diff-d141eea036835fa941bf1672a849a51ccd3c61d9cc9630949ffa97815cb8cc95L11-R25) [[2]](diffhunk://#diff-d141eea036835fa941bf1672a849a51ccd3c61d9cc9630949ffa97815cb8cc95L59-R53)
* Added the new `ProgressPreview` React component in `src/components/previews/components/Progress.tsx`, which supports configurable properties and live code display for the Progress component.

**Property controls for number inputs:**

* Introduced `BoundedNumberProperty` and `ClampedNumberProperty` components for improved handling and validation of numeric properties in previews, enabling dynamic boundaries and clamping of values. [[1]](diffhunk://#diff-c2358d3c18fda60b484fb18eebebb32018bbd47b53a775c1a25c26241fc13f1bR1-R35) [[2]](diffhunk://#diff-0e579b8dda9cc6dc565b62efe67c5b3f78d71fa6143e098be7aed5fbeda6b619R1-R46)
* Exported these new property components in the previews property index for use in other previews.

**Localization enhancements:**

* Added new translation keys for the Progress component label in both German and English translation files (`i18n/de/code.json`, `i18n/en/code.json`) to support internationalization in previews. [[1]](diffhunk://#diff-843dfb758d7b1e771402c27ea8873a0a67360e0cce95ad81da05de4da30ef0a6R401-R403) [[2]](diffhunk://#diff-0c0bae8c07bdc0dd60f43dc298550f978d4df831d7525eb9b6bc0fa145c704ecR401-R403)