### PR TITLE
feat: add AvatarPreview component for enhanced avatar display

### DIFF
--- a/docs/30-components/avatar.mdx
+++ b/docs/30-components/avatar.mdx
@@ -9,8 +9,8 @@ tags:
 ---
 
 import Readme from '../../readmes/avatar/readme.md';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import AvatarPreview from '@site/src/components/previews/components/Avatar';
 
 # Avatar
 
@@ -18,21 +18,10 @@ Synonyme: Persona
 
 Die **Avatar**-Komponente zeigt entweder ein kleines Bild des Users oder dessen Initialen an, falls kein Bild vorhanden ist.
 
-## Konstruktion
-
-### Code
-
-```html
-<kol-avatar _label="Erika Maria Mustermann"></kol-avatar>
-<kol-avatar _label="Erika"></kol-avatar>
-<kol-avatar _src="https://www.w3schools.com/howto/img_avatar.png" _label="Erika Maria Mustermann"></kol-avatar>
-```
-
-### Beispiele
-
-<kol-avatar _label="Erika Maria Mustermann"></kol-avatar>
-<kol-avatar _label="Erika"></kol-avatar>
-<kol-avatar _src="https://www.w3schools.com/howto/img_avatar.png" _label="Erika Maria Mustermann"></kol-avatar>
+<AvatarPreview
+	visibleProperties={['_label', '_color']}
+	codeCollapsable
+/>
 
 ## Verwendung
 
@@ -60,8 +49,6 @@ entsprechend versteckt.
 
 <Readme />
 
+## Beispiele
+
 <ExampleLink component="avatar" />
-
-## Live-Editor
-
-<LiveEditorCompact component="avatar" />

--- a/src/components/previews/components/Avatar.tsx
+++ b/src/components/previews/components/Avatar.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import type { JSX } from '@public-ui/components';
+import { KolInputText, KolAvatar, KolInputColor } from '@public-ui/react-v19';
+
+const AvatarPreview: React.FC = (props: {
+	initialProps?: JSX.KolAvatar;
+	visibleProperties?: (keyof JSX.KolAvatar)[];
+	codeCollapsable?: boolean;
+	codeCollapsed?: boolean;
+}) => {
+	const defaultProps: JSX.KolAvatar = {
+		_label: 'Erika Maria Mustermann',
+        _color: '#5A5FEE',
+	};
+
+	return (
+		<Preview<JSX.KolAvatar>
+			propertyComponents={{
+				_label: <KolInputText _label="Label" />,
+				_src: <KolInputText _label="Image Source (URL)" />,
+				_color: <KolInputColor _label="Color" />,
+			}}
+			initialProps={{ ...defaultProps, ...props.initialProps }}
+			componentName="KolAvatar"
+			visibleProperties={props.visibleProperties}
+			codeCollapsable={props.codeCollapsable}
+			codeCollapsed={props.codeCollapsed}
+			layout={PreviewLayout.CENTERED}
+		>
+			{(props) => <KolAvatar {...props} />}
+		</Preview>
+	);
+};
+
+export default AvatarPreview;


### PR DESCRIPTION
This pull request updates the Avatar component documentation to improve the examples section and introduces a new reusable preview component for Avatars. The main focus is on making the documentation more interactive and maintainable by replacing static code examples with a dynamic preview.

Documentation improvements:

* Replaced static code and example blocks in `docs/30-components/avatar.mdx` with the new `AvatarPreview` component, allowing users to interactively explore the Avatar's properties.
* Updated the structure of the examples and live editor sections to streamline the documentation and provide a more consistent user experience.

Component additions:

* Added a new `AvatarPreview` component in `src/components/previews/components/Avatar.tsx`, which provides a configurable and interactive preview for the Avatar component, supporting properties like `_label` and `_color`.