### PR TITLE
feat: update icon property component to use Kolicons

### DIFF
--- a/src/components/previews/properties/IconProperty.tsx
+++ b/src/components/previews/properties/IconProperty.tsx
@@ -10,12 +10,11 @@ type IconValues = {
 
 const PREDEFINED_ICONS = [
 	{ label: 'None', value: '' },
-	{ label: 'House', value: 'fa-solid fa-house' },
-	{ label: 'Search', value: 'fa-solid fa-search' },
-	{ label: 'User', value: 'fa-solid fa-user' },
-	{ label: 'Heart', value: 'fa-solid fa-heart' },
-	{ label: 'Star', value: 'fa-solid fa-star' },
-	{ label: 'Gear', value: 'fa-solid fa-gear' },
+	{ label: 'KoliBri', value: 'kolicon-kolibri' },
+	{ label: 'Check', value: 'kolicon-check' },
+	{ label: 'House', value: 'kolicon-house' },
+	{ label: 'Wheel', value: 'kolicon-cogwheel' },
+	{ label: 'Eye', value: 'kolicon-eye' },
 ];
 
 const IconProperty = (props: {


### PR DESCRIPTION
This pull request updates the set of predefined icons available in the `IconProperty` component. The change removes several Font Awesome icons and replaces them with a new set of custom `kolicon` icons, updating both the labels and their corresponding values.

**Icon set update:**

* Replaced Font Awesome icons (`fa-solid fa-house`, `fa-solid fa-search`, `fa-solid fa-user`, `fa-solid fa-heart`, `fa-solid fa-star`, `fa-solid fa-gear`) with custom `kolicon` icons (`kolicon-kolibri`, `kolicon-check`, `kolicon-house`, `kolicon-cogwheel`, `kolicon-eye`) in the `PREDEFINED_ICONS` array in `IconProperty.tsx`.