### PR TITLE
feat: add ButtonLinkPreview component

### DIFF
--- a/docs/30-components/button-link.mdx
+++ b/docs/30-components/button-link.mdx
@@ -9,9 +9,8 @@ tags:
 ---
 
 import Readme from '../../readmes/button-link/readme.md';
-import { Configurator } from '@site/src/components/Configurator';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ButtonLinkPreview from '@site/src/components/previews/components/ButtonLink';
 
 # ButtonLink
 
@@ -27,11 +26,17 @@ Da der Link, nicht wie der Button, in mehrere Varianten (`primary` oder `seconda
 
 ## Konstruktion
 
-### Code
-
-```html
-<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
-```
+<ButtonLinkPreview 
+  initialProps={{ _label: 'Schalter sieht wie ein Link aus' }}
+  visibleProperties={[
+    '_label',
+    '_disabled',
+    '_hideLabel',
+    '_icons'
+  ]}
+  codeCollapsable
+  codeCollapsed
+/>
 
 ### Events
 
@@ -42,23 +47,8 @@ Zur Behandlung von Events bzw. Callbacks siehe <kol-link _label="Events" _href="
 | `click`       | Element wird angeklickt                                                                             | `_value`-Property |
 | `onMouseDown` | Eine Taste eines Zeigegeräts wird gedrückt, während der Zeiger sich innerhalb des Elements befindet | -                 |
 
-### Beispiel
-
-<div class="flex gap-2">
-	<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
-</div>
-
 <Readme />
-
-<ExampleLink component="button-link" />
-
-## Live-Editor
-
-<LiveEditorCompact component="button-link" />
 
 ## Beispiele
 
-<Configurator component="button-link" sample="basic" />
-<Configurator component="button-link" sample="icons" />
-<Configurator component="button-link" sample="image" />
-<Configurator component="button-link" sample="target" />
+<ExampleLink component="button-link" />

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/button-link.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/button-link.mdx
@@ -4,9 +4,8 @@ description: Description, specification and examples for the ButtonLink componen
 ---
 
 import Readme from '/readmes/button-link/readme.md';
-import { Configurator } from '@site/src/components/Configurator';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ButtonLinkPreview from '@site/src/components/previews/components/ButtonLink';
 
 # ButtonLink
 
@@ -22,11 +21,17 @@ Since the link, unlike the button, is offered in several variants (primary or se
 
 ## Construction
 
-### Code
-
-```html
-<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
-```
+<ButtonLinkPreview 
+  initialProps={{ _label: 'Schalter sieht wie ein Link aus' }}
+  visibleProperties={[
+    '_label',
+    '_disabled',
+    '_hideLabel',
+    '_icons'
+  ]}
+  codeCollapsable
+  codeCollapsed
+/>
 
 ### Events
 
@@ -37,23 +42,8 @@ For the handling of events or callbacks, see <kol-link _label="Events" _href="..
 | `click` | Element is clicked | `_value` property |
 | `onMouseDown` | A pointing device key is pressed while the pointer is inside the element | - |
 
-### Example
-
-<div class="flex gap-2">
-	<kol-button-link _on="" _label="Schalter sieht wie ein Link aus"></kol-button-link>
-</div>
-
 <Readme />
-
-<ExampleLink component="button-link" />
-
-## Live editor
-
-<LiveEditorCompact component="button-link" />
 
 ## Examples
 
-<Configurator component="button-link" sample="basic" />
-<Configurator component="button-link" sample="icons" />
-<Configurator component="button-link" sample="image" />
-<Configurator component="button-link" sample="target" />
+<ExampleLink component="button-link" />

--- a/src/components/previews/components/ButtonLink.tsx
+++ b/src/components/previews/components/ButtonLink.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import { BooleanProperty, AlignProperty, IconProperty } from '../properties';
+import type { JSX } from '@public-ui/components';
+import { KolInputText, KolButtonLink } from '@public-ui/react-v19';
+
+const ButtonLinkPreview: React.FC = (props: {
+    initialProps?: JSX.KolButtonLink;
+    visibleProperties?: (keyof JSX.KolButtonLink)[];
+    codeCollapsable?: boolean;
+    codeCollapsed?: boolean;
+}) => {
+    const defaultProps: JSX.KolButtonLink = {
+        _label: 'ButtonLink',
+    };
+
+    return (
+        <Preview<JSX.KolButtonLink>
+            propertyComponents={{
+                _label: <KolInputText _label="Label" />,
+                _tooltipAlign: <AlignProperty label="Tooltip Align" defaultValue="top" />,
+                _icons: <IconProperty label="Icons" />,
+                _accessKey: <KolInputText _label="Access Key" />,
+                _ariaControls: <KolInputText _label="ARIA Controls" />,
+                _ariaDescription: <KolInputText _label="ARIA Description" />,
+                _name: <KolInputText _label="Name" />,
+                _shortKey: <KolInputText _label="Short Key" _maxLength={1} />,
+                _value: <KolInputText _label="Value" />,
+                _disabled: <BooleanProperty label="Disabled" />,
+                _hideLabel: <BooleanProperty label="Hide Label" />,
+                _inline: <BooleanProperty label="Inline" />,
+                _ariaExpanded: <BooleanProperty label="ARIA Expanded" />,
+                _ariaSelected: <BooleanProperty label="ARIA Selected" />,
+            }}
+            initialProps={{ ...defaultProps, ...props.initialProps }}
+            componentName="KolButtonLink"
+            visibleProperties={props.visibleProperties}
+            codeCollapsable={props.codeCollapsable}
+            codeCollapsed={props.codeCollapsed}
+            layout={PreviewLayout.CENTERED}
+        >
+            {(props) => <KolButtonLink {...props} />}
+        </Preview>
+    );
+};
+
+export default ButtonLinkPreview;


### PR DESCRIPTION
This pull request refactors the documentation for the `ButtonLink` component in both German and English, replacing inline code samples and live editors with a new interactive preview component. It introduces the `ButtonLinkPreview` React component to provide a more consistent and maintainable way to demonstrate the component's properties and usage. The changes improve the user experience and simplify the documentation codebase.

**Documentation improvements:**

* Replaced inline HTML code samples and live editors in `docs/30-components/button-link.mdx` and `i18n/en/docusaurus-plugin-content-docs/current/30-components/button-link.mdx` with the new `ButtonLinkPreview` component, allowing interactive exploration of properties and examples. [[1]](diffhunk://#diff-081be1a1afa260e4c4974800d2682e2fb9394b71751cd31580145a201f27bca0L12-R13) [[2]](diffhunk://#diff-081be1a1afa260e4c4974800d2682e2fb9394b71751cd31580145a201f27bca0L30-R39) [[3]](diffhunk://#diff-081be1a1afa260e4c4974800d2682e2fb9394b71751cd31580145a201f27bca0L45-R54) [[4]](diffhunk://#diff-58503b0b802f70ccd32425f0c581ac8adee8d1c7d72034ef406293d6565aedcbL7-R8) [[5]](diffhunk://#diff-58503b0b802f70ccd32425f0c581ac8adee8d1c7d72034ef406293d6565aedcbL25-R34) [[6]](diffhunk://#diff-58503b0b802f70ccd32425f0c581ac8adee8d1c7d72034ef406293d6565aedcbL40-R49)

**Component addition:**

* Added the new `ButtonLinkPreview` React component in `src/components/previews/components/ButtonLink.tsx`, which supports configurable properties, code collapsing, and a centered layout for previewing the `KolButtonLink`.

---

Closes #530 