### PR TITLE
feat: add ToolbarPreview component for enhanced toolbar visualization in documentation

### DIFF
--- a/docs/30-components/toolbar.mdx
+++ b/docs/30-components/toolbar.mdx
@@ -9,21 +9,17 @@ tags:
 
 import Readme from '../../readmes/toolbar/readme.md';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ToolbarPreview from '@site/src/components/previews/components/Toolbar';
 
 # Toolbar
 
 Die Komponente **Toolbar** ist eine Sammlung häufig verwendeter Steuerelemente für Schaltflächen und Links, die in einer kompakten visuellen Form zusammengefasst sind. Die Toolbar ist in der Regel eine Untermenge von Funktionen, die in einer Menüleiste zu finden sind, um den Aufwand für den Benutzer zu verringern.
 
-```html
-<kol-toolbar _label="Label" _items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link",  type="link"}]'> </kol-toolbar>
-```
-
-### Beispiel
-
-<kol-toolbar
-        _label="Label"
-        _items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link", type="link"}]'>
-</kol-toolbar>
+<ToolbarPreview 
+  visibleProperties={['_orientation'  ]}
+  codeCollapsable
+  codeCollapsed
+/>
 
 ## Verwendung
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/toolbar.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/toolbar.mdx
@@ -5,21 +5,17 @@ description: Description and specification for the toolbar component.
 
 import Readme from '/readmes/toolbar/readme.md';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ToolbarPreview from '@site/src/components/previews/components/Toolbar';
 
 # Toolbar
 
 The **Toolbar** component is a collection of commonly used button and link controls summarized in a compact visual form. The toolbar is typically a subset of functions found in a menu bar to reduce user effort.
 
-```html
-<kol-toolbar _label="Label" _items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link",  type="link"}]'> </kol-toolbar>
-```
-
-### Example
-
-<kol-toolbar
-_label="Label"
-_items='[{"_label": "Button", type="button"}, {"_href": "#", "_label": "Link", type="link"}]'>
-</kol-toolbar>
+<ToolbarPreview 
+  visibleProperties={['_orientation'  ]}
+  codeCollapsable
+  codeCollapsed
+/>
 
 ## Usage
 

--- a/src/components/previews/components/Toolbar.tsx
+++ b/src/components/previews/components/Toolbar.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import type { JSX } from '@public-ui/components';
+import { KolInputText, KolSelect, KolTextarea, KolToolbar } from '@public-ui/react-v19';
+
+const ToolbarPreview: React.FC = (props: {
+	initialProps?: JSX.KolToolbar;
+	visibleProperties?: (keyof JSX.KolToolbar)[];
+	codeCollapsable?: boolean;
+	codeCollapsed?: boolean;
+}) => {
+	const defaultProps: JSX.KolToolbar = {
+		_label: 'Toolbar',
+		_items: [
+			{
+				type: 'button',
+				_label: 'Back',
+				_hideLabel: true,
+				_icons: {
+					left: {
+						icon: 'kolicon-chevron-left',
+					},
+				},
+			},
+			{
+				type: 'button',
+				_label: 'Next',
+				_hideLabel: true,
+				_icons: {
+					right: {
+						icon: 'kolicon-chevron-right',
+					},
+				},
+			},
+			{
+				type: 'link',
+				_href: '#',
+				_label: 'Link',
+			},
+			{
+				type: 'button',
+				_label: 'Button',
+			},
+		],
+	};
+
+	const [itemsJson, setItemsJson] = React.useState<string>(JSON.stringify(defaultProps._items, null, 2));
+	const [itemsError, setItemsError] = React.useState<string>('');
+
+	const parseItems = (json: string) => {
+		try {
+			const parsed = JSON.parse(json) as JSX.KolToolbar['_items'];
+			setItemsError('');
+			return parsed;
+		} catch {
+			setItemsError('Invalid JSON');
+			return defaultProps._items;
+		}
+	};
+
+	return (
+		<Preview<JSX.KolToolbar>
+			propertyComponents={{
+				_label: <KolInputText _label="Label" />,
+				_orientation: (
+					<KolSelect
+						_label="Orientation"
+						_options={[
+							{ label: 'Default', value: '' },
+							{ label: 'Horizontal', value: 'horizontal' },
+							{ label: 'Vertical', value: 'vertical' },
+						]}
+					/>
+				),
+				_items: (
+					<KolTextarea
+						_label="Items (JSON)"
+						_rows={15}
+						_msg={itemsError ? { _type: 'error', _description: itemsError } : undefined}
+						_on={{
+							onInput: (_: Event, v: unknown) => {
+								setItemsJson(v as string);
+							},
+						}}
+						_value={itemsJson}
+					/>
+				),
+			}}
+			initialProps={{ ...defaultProps, ...props.initialProps }}
+			componentName="KolToolbar"
+			visibleProperties={props.visibleProperties}
+			codeCollapsable={props.codeCollapsable}
+			codeCollapsed={props.codeCollapsed}
+			layout={PreviewLayout.CENTERED}
+		>
+			{(props) => <KolToolbar {...props} _items={parseItems(itemsJson)} />}
+		</Preview>
+	);
+};
+
+export default ToolbarPreview;


### PR DESCRIPTION
This pull request updates the documentation for the Toolbar component by replacing static code examples with an interactive preview, and introduces a new `ToolbarPreview` React component to support this. The changes improve the usability of the documentation by allowing users to interactively explore the Toolbar's properties, especially the `_orientation` and `_items` props.

**Documentation improvements:**

* Replaced static HTML examples in both the German (`docs/30-components/toolbar.mdx`) and English (`i18n/en/docusaurus-plugin-content-docs/current/30-components/toolbar.mdx`) Toolbar documentation with a new interactive `<ToolbarPreview>` component, making it easier for users to experiment with the Toolbar's properties. [[1]](diffhunk://#diff-d55e04e4ae8a07e8458b3dfe5b795e6957d35a78933640234a4eedf9b71a83c7R12-R22) [[2]](diffhunk://#diff-77170f8b4cc3f5261362b620d7296cae74eda96c750e2a1d7a8765fb551c8590R8-R18)

**Component additions:**

* Added the new `ToolbarPreview` React component (`src/components/previews/components/Toolbar.tsx`), which provides an interactive preview for the Toolbar. It supports editing properties such as `_label`, `_orientation`, and `_items` (with live JSON editing and error handling), and integrates with the documentation preview system.