### PR TITLE
feat: add ComboboxPreview; update related documentation

### DIFF
--- a/docs/30-components/combobox.mdx
+++ b/docs/30-components/combobox.mdx
@@ -9,6 +9,7 @@ tags:
 
 import Readme from '../../readmes/combobox/readme.md';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import ComboboxPreview from '@site/src/components/previews/components/Combobox';
 
 # Combobox
 
@@ -16,13 +17,18 @@ Synonyme: Autocomplete, Select, Dropdown
 
 Die **Combobox**-Komponente erzeugt eine Auswahlliste, die ein Eingabefeld mit einer darunter angezeigten Liste von auswählbaren Optionen kombiniert.
 
+<ComboboxPreview
+  initialProps={{ _label: 'Freie Eingabe mit Vorschlägen'  }}
+  visibleProperties={[
+    '_label',
+    '_msg',
+    '_icons',
+    '_disabled'
+  ]}
+  codeCollapsable
+  codeCollapsed
+/>
 ## Konstruktion
-
-### Code
-
-```html
-<kol-combobox _suggestions="['Herr','Frau','Firma']" _label="Anrede" _value="Herr"></kol-combobox>
-```
 
 ### Events
 
@@ -36,10 +42,6 @@ Zur Behandlung von Events bzw. Callbacks siehe <kol-link _label="Events" _href="
 | `input`  | Wert wird durch Eingabe geändert | Aktueller Wert des Eingabefelds |
 | `change` | Eingabe wurde abgeschlossen      | Aktueller Wert des Eingabefelds |
 
-### Beispiel
-
-<kol-combobox  _suggestions="['Herr','Frau','Firma']" _label="Anrede" _value="Herr"></kol-combobox>
-
 ## Verwendung
 
 Die Auswahlmöglichkeiten werden über das Attribut **`_suggestions`** als JSON-Array an die Komponente übergeben.
@@ -49,10 +51,6 @@ Beispiel für die Konstruktion des JSON-Array:
 ```json
 ["Herr", "Frau", "Firma"]
 ```
-
-<!--### Best practices-->
-
-<!-- ## Barrierefreiheit -->
 
 ### Tastatursteuerung
 
@@ -70,5 +68,7 @@ Beispiel für die Konstruktion des JSON-Array:
 | `Druckbare Zeichen`            | Fokussiert die erste Option, die mit dem gedrückten Zeichen beginnt.                                                                                                                                |
 
 <Readme />
+
+## Beispiele 
 
 <ExampleLink component="combobox" />

--- a/docs/30-components/textarea.mdx
+++ b/docs/30-components/textarea.mdx
@@ -21,7 +21,7 @@ Standard-Textarea mit Beschriftung und Platzhaltertext:
 
 <TextAreaPreview 
   _value="" 
-  visibleProperties={["_value", "_placeholder", "_label", "_hint"]} 
+  visibleProperties={["_value", "_placeholder", "_label", "_hint", "_msg"]} 
   initialProps={{ _label: "Beschreibung", _placeholder: "Bitte geben Sie Ihre Beschreibung ein...", _hint: "Ergänzende Hinweise zum Eingabefeld", _rows: 4 }}
   codeCollapsable
   codeCollapsed

--- a/src/components/previews/components/Combobox.tsx
+++ b/src/components/previews/components/Combobox.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import { BooleanProperty, IconsProperty, MsgProperty } from '../properties';
+import type { JSX } from '@public-ui/components';
+import { KolCombobox, KolInputText, KolTextarea } from '@public-ui/react-v19';
+
+const ComboboxPreview: React.FC = (props: {
+    initialProps?: JSX.KolCombobox;
+    visibleProperties?: (keyof JSX.KolCombobox)[];
+    codeCollapsable?: boolean;
+    codeCollapsed?: boolean;
+}) => {
+    const defaultProps: JSX.KolCombobox = {
+        _label: 'Anrede',
+        _suggestions: ['Herr', 'Frau', 'Firma'],
+    };
+
+    const [value, setValue] = React.useState<string>('');
+
+    return (
+        <Preview<JSX.KolCombobox>
+            propertyComponents={{
+                _label: <KolInputText _label="Label" />,
+                _placeholder: <KolInputText _label="Placeholder" />,
+                _suggestions: <KolTextarea _label="Suggestions (JSON Array)" _rows={5} />,
+                _icons: <IconsProperty label="Icons" directions={['right', 'left']} />,
+                _accessKey: <KolInputText _label="Access Key" />,
+                _name: <KolInputText _label="Name" />,
+                _hint: <KolInputText _label="Hint" />,
+                _msg: <MsgProperty label="Message" />,
+                _disabled: <BooleanProperty label="Disabled" />,
+                _required: <BooleanProperty label="Required" />,
+                _hasClearButton: <BooleanProperty label="Has Clear Button" />,
+                _hideLabel: <BooleanProperty label="Hide Label" />,
+                _hideMsg: <BooleanProperty label="Hide Message" />,
+                _touched: <BooleanProperty label="Touched" />,
+            }}
+            initialProps={{ ...defaultProps, ...props.initialProps }}
+            componentName="KolCombobox"
+            visibleProperties={props.visibleProperties}
+            codeCollapsable={props.codeCollapsable}
+            codeCollapsed={props.codeCollapsed}
+            layout={PreviewLayout.CENTERED}
+        >
+            {(props) => (
+                <KolCombobox _touched {...props} _on={{ onInput: (_: Event, v: unknown) => setValue(v as string) }} _value={value} />
+            )}
+        </Preview>
+    );
+};
+
+export default ComboboxPreview;

--- a/src/components/previews/components/InputText.tsx
+++ b/src/components/previews/components/InputText.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Preview, { PreviewLayout } from '../Preview';
-import { BooleanProperty, IconsProperty, SmartButtonProperty } from '../properties';
+import { BooleanProperty, IconsProperty, MsgProperty, SmartButtonProperty } from '../properties';
 import type { JSX } from '@public-ui/components';
 import { KolInputNumber, KolInputText, KolSelect } from '@public-ui/react-v19';
 
@@ -24,7 +24,7 @@ const InputTextPreview: React.FC = (props: {
                 _accessKey: <KolInputText _label="Access Key" />,
                 _name: <KolInputText _label="Name" />,
                 _hint: <KolInputText _label="Hint" />,
-                _msg: <KolInputText _label="Message" />,
+                _msg: <MsgProperty label="Message" />,
                 _maxLength: <KolInputNumber _label="Max Length" _min={0} />,
                 _maxLengthBehavior: (
                     <KolSelect

--- a/src/components/previews/components/Textarea.tsx
+++ b/src/components/previews/components/Textarea.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Preview from '../Preview';
-import { BooleanProperty, ResizeProperty } from '../properties';
+import { BooleanProperty, MsgProperty, ResizeProperty } from '../properties';
 import type { JSX } from '@public-ui/components';
 import { KolInputText, KolInputNumber, KolTextarea, KolSelect } from '@public-ui/react-v19';
 
@@ -22,7 +22,7 @@ const TextAreaPreview: React.FC = (props: {
 				_label: <KolInputText _label="Label" />,
 				_placeholder: <KolInputText _label="Placeholder" />,
 				_hint: <KolInputText _label="Hint" />,
-				_msg: <KolInputText _label="Error message" />,
+				_msg: <MsgProperty label="Message" />,
 				_rows: <KolInputNumber _label="Rows" _min={1} _max={20} />,
 				_maxLength: <KolInputNumber _label="Max Length" _min={1} _max={1000} />,
 				_maxLengthBehavior: (

--- a/src/components/previews/properties/IconsProperty.tsx
+++ b/src/components/previews/properties/IconsProperty.tsx
@@ -1,4 +1,4 @@
-import { KolSingleSelect } from '@public-ui/react-v19';
+import { KolSelect } from '@public-ui/react-v19';
 import React, { useState } from 'react';
 
 type IconValues = {
@@ -42,11 +42,11 @@ const IconsProperty = (props: {
 	};
 
 	return (
-		<fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+		<fieldset >
 			<legend>{props.label}</legend>
 			<div className="grid grid-cols-2 gap-2">
 				{props.directions?.includes('left') !== false &&
-					<KolSingleSelect
+					<KolSelect
 						_label="Left"
 						_options={PREDEFINED_ICONS}
 						_value={icons.left}
@@ -57,7 +57,7 @@ const IconsProperty = (props: {
 						}}
 					/>}
 				{props.directions?.includes('right') !== false &&
-					<KolSingleSelect
+					<KolSelect
 						_label="Right"
 						_options={PREDEFINED_ICONS}
 						_value={icons.right}
@@ -68,7 +68,7 @@ const IconsProperty = (props: {
 						}}
 					/>}
 				{props.directions?.includes('top') !== false &&
-					<KolSingleSelect
+					<KolSelect
 						_label="Top"
 						_options={PREDEFINED_ICONS}
 						_value={icons.top}
@@ -79,7 +79,7 @@ const IconsProperty = (props: {
 						}}
 					/>}
 				{props.directions?.includes('bottom') !== false &&
-					<KolSingleSelect
+					<KolSelect
 						_label="Bottom"
 						_options={PREDEFINED_ICONS}
 						_value={icons.bottom}

--- a/src/components/previews/properties/MsgProperty.tsx
+++ b/src/components/previews/properties/MsgProperty.tsx
@@ -1,0 +1,59 @@
+import { KolInputText, KolSelect } from '@public-ui/react-v19';
+import React from 'react';
+
+const MsgProperty = (props: {
+    label: string;
+    _value?: { _type: string; _description: string } | string;
+    _on?: {
+        onInput?: (event: Event, value: unknown) => void;
+    };
+}) => {
+    const [type, setType] = React.useState<string>(
+        typeof props._value === 'object' && props._value?._type ? props._value._type : 'error'
+    );
+    const [description, setDescription] = React.useState<string>(
+        typeof props._value === 'object' && props._value?._description ? props._value._description : ''
+    );
+
+    const handleTypeChange = (_event: Event, value: unknown) => {
+        const newType = value as string;
+        setType(newType);
+        const newValue = description ? { _type: newType, _description: description } : undefined;
+        props._on?.onInput?.(_event, newValue);
+    };
+
+    const handleDescriptionChange = (_event: Event, value: unknown) => {
+        const newDescription = value as string;
+        setDescription(newDescription);
+        const newValue = newDescription ? { _type: type, _description: newDescription } : undefined;
+        props._on?.onInput?.(_event, newValue);
+    };
+
+    return (
+        <fieldset>
+            <legend>{props.label}</legend>
+            <div className='flex flex-row gap-2'>
+                <KolSelect
+                    _label="Type"
+                    _value={[type]}
+                    _options={[
+                        { label: 'Error', value: 'error' },
+                        { label: 'Warning', value: 'warning' },
+                        { label: 'Info', value: 'info' },
+                        { label: 'Success', value: 'success' },
+                        { label: 'Default', value: 'default' },
+                    ]}
+                    _on={{ onChange: handleTypeChange }}
+                />
+                <KolInputText
+                    _label="Description"
+                    _value={description}
+                    _placeholder="Enter message description"
+                    _on={{ onInput: handleDescriptionChange }}
+                />
+            </div>
+        </fieldset>
+    );
+};
+
+export default MsgProperty;

--- a/src/components/previews/properties/index.ts
+++ b/src/components/previews/properties/index.ts
@@ -9,6 +9,7 @@ export { default as CustomCssProperty } from './CustomCssProperty';
 export { default as IconsProperty } from './IconsProperty';
 export { default as LevelProperty } from './LevelProperty';
 export { default as LinksProperty } from './LinksProperty';
+export { default as MsgProperty } from './MsgProperty';
 export { default as MultiLineTextProperty } from './MultiLineText';
 export { default as ResizeProperty } from './ResizeProperty';
 export { default as SmartButtonProperty } from './SmartButtonProperty';


### PR DESCRIPTION
This pull request introduces a new `ComboboxPreview` component for previewing and configuring the Combobox UI component, and refactors how message (`_msg`) properties are handled in component previews. It also updates documentation to use the new preview and improves consistency in property editors for various components.

**Component Previews and Property Editors:**

* Added a new `ComboboxPreview` React component to allow interactive preview and configuration of the Combobox component in documentation. (`src/components/previews/components/Combobox.tsx`)
* Introduced a reusable `MsgProperty` component for editing message properties, and updated `InputTextPreview` and `TextAreaPreview` to use it for the `_msg` property, replacing simple text input with a type and description editor. (`src/components/previews/properties/MsgProperty.tsx`, `src/components/previews/components/InputText.tsx`, `src/components/previews/components/Textarea.tsx`, `src/components/previews/properties/index.ts`) [[1]](diffhunk://#diff-1e4b2fcb2c0687bbd95f7bb177d42e6c3d5497eb2b7146f2047354ecbe6cf832R1-R59) [[2]](diffhunk://#diff-bebc4ae01a3b019408be51febb28b721340b315e943dc55ec2c4765db1e1a159L3-R3) [[3]](diffhunk://#diff-bebc4ae01a3b019408be51febb28b721340b315e943dc55ec2c4765db1e1a159L27-R27) [[4]](diffhunk://#diff-f975a93390ede4471be99323049d1f7ed1ee01cb3c31c4a19cdda32630c2b5f6L3-R3) [[5]](diffhunk://#diff-f975a93390ede4471be99323049d1f7ed1ee01cb3c31c4a19cdda32630c2b5f6L25-R25) [[6]](diffhunk://#diff-e30cd75cc8ff8dba3e451f31e672f9918656364f4c061a86c943f5e889f49bf7R12)
* Updated `IconsProperty` to use `KolSelect` instead of `KolSingleSelect` for better consistency and compatibility. (`src/components/previews/properties/IconsProperty.tsx`) [[1]](diffhunk://#diff-4292098cdd95cd6a75e9a954605201ace22b0c76cd73a177c8dfc99b41f99b73L1-R1) [[2]](diffhunk://#diff-4292098cdd95cd6a75e9a954605201ace22b0c76cd73a177c8dfc99b41f99b73L45-R49) [[3]](diffhunk://#diff-4292098cdd95cd6a75e9a954605201ace22b0c76cd73a177c8dfc99b41f99b73L60-R60) [[4]](diffhunk://#diff-4292098cdd95cd6a75e9a954605201ace22b0c76cd73a177c8dfc99b41f99b73L71-R71) [[5]](diffhunk://#diff-4292098cdd95cd6a75e9a954605201ace22b0c76cd73a177c8dfc99b41f99b73L82-R82)

**Documentation Improvements:**

* Updated the Combobox documentation to use the new `ComboboxPreview` component, removed redundant static code examples, and reorganized sections for clarity. (`docs/30-components/combobox.mdx`) [[1]](diffhunk://#diff-77e220d78d782325d0e265c7bb0b0fcc0414a73fc796677775779b8b9abb1806R12-L26) [[2]](diffhunk://#diff-77e220d78d782325d0e265c7bb0b0fcc0414a73fc796677775779b8b9abb1806L39-L42) [[3]](diffhunk://#diff-77e220d78d782325d0e265c7bb0b0fcc0414a73fc796677775779b8b9abb1806L53-L56) [[4]](diffhunk://#diff-77e220d78d782325d0e265c7bb0b0fcc0414a73fc796677775779b8b9abb1806R72-R73)
* Added the `_msg` property to the visible properties for the Textarea preview in documentation for completeness. (`docs/30-components/textarea.mdx`)

---

Closes: #533 