### PR TITLE
fix(minify): exclude JSON files from minification process

### DIFF
--- a/scripts/minify.js
+++ b/scripts/minify.js
@@ -11,7 +11,7 @@ function minifyFiles(dir) {
 	dirItems.forEach((dirItem) => {
 		const dirItemPath = path.resolve(dir, dirItem);
 		const stats = fs.lstatSync(dirItemPath);
-		if (stats.isFile() && /(htaccess|robots)/.test(dirItemPath) === false) {
+		if (stats.isFile() && /(htaccess|robots)/.test(dirItemPath) === false && !dirItemPath.endsWith('.json')) {
 			let code = fs.readFileSync(dirItemPath, { encoding: 'utf-8' });
 			minify(code, options)
 				.then((result) => {


### PR DESCRIPTION
This pull request introduces a small but important update to the `minifyFiles` function in `scripts/minify.js`. The change ensures that `.json` files are excluded from the minification process.

File processing improvement:

* Updated the file filter in `minifyFiles` to skip files ending with `.json`, preventing accidental minification of JSON files.