### PR TITLE
feat(form-preview): add FormPreview component with initial props and translations

### DIFF
--- a/docs/30-components/form.mdx
+++ b/docs/30-components/form.mdx
@@ -20,7 +20,7 @@ Die **Form**-Komponente dient dazu alle Eingabefelder zu umschließen, den Hinwe
 
 <FormPreview visibleProperties={['_requiredText']} codeCollapsable codeCollapsed />
 
-# API
+## API
 
 <Readme />
 

--- a/docs/30-components/form.mdx
+++ b/docs/30-components/form.mdx
@@ -9,8 +9,8 @@ tags:
 ---
 
 import Readme from '../../readmes/form/readme.md';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import FormPreview from '@site/src/components/previews/components/Form';
 
 # Form
 
@@ -18,26 +18,12 @@ Die **Form**-Komponente dient dazu alle Eingabefelder zu umschließen, den Hinwe
 
 ## Konstruktion
 
-### Code
+<FormPreview visibleProperties={['_requiredText']} codeCollapsable codeCollapsed />
 
-```html
-<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
-	<kol-input-text _label="Vorname"></kol-input-text>
-	<kol-input-text _label="Nachname"></kol-input-text>
-</kol-form>
-```
-
-### Beispiel
-
-<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
-	<kol-input-text _label="Vorname"></kol-input-text>
-	<kol-input-text _label="Nachname"></kol-input-text>
-</kol-form>
+# API
 
 <Readme />
 
+## Beispiele
+
 <ExampleLink component="form" />
-
-## Live-Editor
-
-<LiveEditorCompact component="form" />

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -477,6 +477,24 @@
 	"preview.component.combobox.label": {
 		"message": "Anrede"
 	},
+	"preview.component.form.label": {
+		"message": "Sternchen heißt Pflichtfeld."
+	},
+	"preview.component.form.first-name": {
+		"message": "Vorname"
+	},
+	"preview.component.form.last-name": {
+		"message": "Nachname"
+	},
+	"preview.component.form.email": {
+		"message": "E-Mail"
+	},
+	"preview.component.form.submit": {
+		"message": "Senden"
+	},
+	"preview.component.form.reset": {
+		"message": "Zurücksetzen"
+	},
 	"preview.component.input-checkbox.label": {
 		"message": "Checkbox"
 	},

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -477,6 +477,24 @@
 	"preview.component.combobox.label": {
 		"message": "Salutation"
 	},
+	"preview.component.form.label": {
+		"message": "Asterisk means required field."
+	},
+	"preview.component.form.first-name": {
+		"message": "First name"
+	},
+	"preview.component.form.last-name": {
+		"message": "Last name"
+	},
+	"preview.component.form.email": {
+		"message": "Email"
+	},
+	"preview.component.form.submit": {
+		"message": "Submit"
+	},
+	"preview.component.form.reset": {
+		"message": "Reset"
+	},
 	"preview.component.input-checkbox.label": {
 		"message": "Checkbox"
 	},

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
@@ -15,7 +15,7 @@ The **Form** component is used to enclose all input fields, to correctly positio
 
 <FormPreview visibleProperties={['_requiredText']} codeCollapsable codeCollapsed />
 
-# API
+## API
 
 <Readme />
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/form.mdx
@@ -4,8 +4,8 @@ description: Description, specification and examples for the Form component.
 ---
 
 import Readme from '/readmes/form/readme.md';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import FormPreview from '@site/src/components/previews/components/Form';
 
 # Form
 
@@ -13,26 +13,12 @@ The **Form** component is used to enclose all input fields, to correctly positio
 
 ## Construction
 
-### Code
+<FormPreview visibleProperties={['_requiredText']} codeCollapsable codeCollapsed />
 
-```html
-<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
-	<kol-input-text _label="Vorname"></kol-input-text>
-	<kol-input-text _label="Nachname"></kol-input-text>
-</kol-form>
-```
-
-### Example
-
-<kol-form _requiredText="Sternchen heißt Pflichtfeld.">
-	<kol-input-text _label="Vorname"></kol-input-text>
-	<kol-input-text _label="Nachname"></kol-input-text>
-</kol-form>
+# API
 
 <Readme />
 
+## Examples
+
 <ExampleLink component="form" />
-
-## Live editor
-
-<LiveEditorCompact component="form" />

--- a/src/components/previews/components/Form.tsx
+++ b/src/components/previews/components/Form.tsx
@@ -32,7 +32,7 @@ const FormPreview: React.FC<FormPreviewComponentProps> = (props) => {
             layout={PreviewLayout.FULL_SIZE}
         >
             {(componentProps) => (
-                <KolForm {...componentProps} className="block w-full" style={{ width: '100%' }}>
+                <KolForm {...componentProps} className="block w-full">
                     <div className="grid w-full gap-2">
                         <KolInputText _label={translate({ id: 'preview.component.form.first-name' })} _required _name="first-name" />
                         <KolInputText _label={translate({ id: 'preview.component.form.last-name' })} _required _name="last-name" />

--- a/src/components/previews/components/Form.tsx
+++ b/src/components/previews/components/Form.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import type { JSX } from '@public-ui/components';
+import { KolButton, KolInputEmail, KolInputText, KolForm } from '@public-ui/react-v19';
+import { translate } from '@docusaurus/Translate';
+
+interface FormPreviewComponentProps {
+    initialProps?: JSX.KolForm;
+    visibleProperties?: (keyof JSX.KolForm)[];
+    codeCollapsable?: boolean;
+    codeCollapsed?: boolean;
+}
+
+const FormPreview: React.FC<FormPreviewComponentProps> = (props) => {
+    const defaultProps = React.useMemo<JSX.KolForm>(
+        () => ({
+            _requiredText: translate({ id: 'preview.component.form.label' }),
+        }),
+        [],
+    );
+
+    return (
+        <Preview<JSX.KolForm>
+            propertyComponents={{
+                _requiredText: <KolInputText _label="Required text" />,
+            }}
+            initialProps={{ ...defaultProps, ...props.initialProps }}
+            componentName="KolForm"
+            visibleProperties={props.visibleProperties}
+            codeCollapsable={props.codeCollapsable}
+            codeCollapsed={props.codeCollapsed}
+            layout={PreviewLayout.FULL_SIZE}
+        >
+            {(componentProps) => (
+                <KolForm {...componentProps} className="block w-full" style={{ width: '100%' }}>
+                    <div className="grid w-full gap-2">
+                        <KolInputText _label={translate({ id: 'preview.component.form.first-name' })} _required _name="first-name" />
+                        <KolInputText _label={translate({ id: 'preview.component.form.last-name' })} _required _name="last-name" />
+                        <KolInputEmail _label={translate({ id: 'preview.component.form.email' })} _required _name="email" />
+                        <div className="flex gap-2 pt-2">
+                            <KolButton _label={translate({ id: 'preview.component.form.submit' })} _type="submit" />
+                            <KolButton _label={translate({ id: 'preview.component.form.reset' })} _type="reset" _variant="secondary" />
+                        </div>
+                    </div>
+                </KolForm>
+            )}
+        </Preview>
+    );
+};
+
+export default FormPreview;


### PR DESCRIPTION
This pull request updates the documentation and preview functionality for the Form component, focusing on improving the developer experience and internationalization support. The main changes include replacing static code examples and the live editor with a new interactive `FormPreview` component, and adding new translation keys for form-related labels in both English and German.

**Documentation and Preview Improvements:**

- Replaced static HTML code examples and the `LiveEditorCompact` with the new interactive `FormPreview` component in both the English and German Form documentation files (`form.mdx`). This streamlines the documentation and provides a more consistent preview experience. [[1]](diffhunk://#diff-cfde69b6bdbf22c05b138152dab7914de7acae7892f1b807a04eacdd0a73ba61L7-R24) [[2]](diffhunk://#diff-72ca3c2db6d146e2e74cf286ef842475f041f61f730319012dabdeedd04155aeL12-R29)
- Added the new `FormPreview` React component, which renders an interactive form preview using the Kolibri UI components and supports configurable properties for demonstration purposes.

**Internationalization Enhancements:**

- Added new translation keys for all form-related labels (e.g., required text, first name, last name, email, submit, reset) to both the English and German translation files (`code.json`). This ensures that the form preview is fully localized. [[1]](diffhunk://#diff-0c0bae8c07bdc0dd60f43dc298550f978d4df831d7525eb9b6bc0fa145c704ecR480-R497) [[2]](diffhunk://#diff-843dfb758d7b1e771402c27ea8873a0a67360e0cce95ad81da05de4da30ef0a6R480-R497)