### PR TITLE
feat(link-button): add LinkButtonPreview component

### DIFF
--- a/docs/30-components/link-button.mdx
+++ b/docs/30-components/link-button.mdx
@@ -1,17 +1,11 @@
 ---
 title: LinkButton
 description: Beschreibung, Spezifikation und Beispiele für die LinkButton-Komponente.
-tags:
-  - LinkButton
-  - Beschreibung
-  - Spezifikation
-  - Beispiele
 ---
 
 import Readme from '../../readmes/link-button/readme.md';
-import { Configurator } from '@site/src/components/Configurator';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import LinkButtonPreview from '@site/src/components/previews/components/LinkButton';
 
 # LinkButton
 
@@ -20,15 +14,11 @@ Weitere Informationen zum Aussehen finden Sie auf der <kol-link _href="../compon
 
 ## Konstruktion
 
-### Code
-
-```html
-<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-<kol-link-button _href="#" _label="Secondary" _variant="danger"></kol-link-button>
-<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_label', '_href', '_variant', '_disabled']}
+	codeCollapsable
+	codeCollapsed
+/>
 
 ### Events
 
@@ -38,24 +28,10 @@ Zur Behandlung von Events bzw. Callbacks siehe <kol-link _label="Events" _href="
 |---------|-------------------------|------------------|
 | `click` | Element wird angeklickt | `_href`-Property |
 
-### Beispiel
-
-<div class="flex gap-2">
-	<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-	<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-	<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-	<kol-link-button _href="#" _label="Danger" _variant="danger"></kol-link-button>
-	<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-</div>
+# API
 
 <Readme />
 
-<ExampleLink component="link-button" />
-
-## Live-Editor
-
-<LiveEditorCompact component="link-button" />
-
 ## Beispiele
 
-<Configurator component="link-button" sample="basic" />
+<ExampleLink component="link-button" />

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -420,6 +420,12 @@
 	"preview.component.link.label": {
 		"message": "KoliBri - Public UI"
 	},
+	"preview.component.link-button.href": {
+		"message": "https://public-ui.github.io/docs"
+	},
+	"preview.component.link-button.label": {
+		"message": "LinkButton"
+	},
 	"preview.component.progress.label": {
 		"message": "Fortschritt"
 	},

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -420,6 +420,12 @@
 	"preview.component.link.label": {
 		"message": "KoliBri - Public UI"
 	},
+	"preview.component.link-button.href": {
+		"message": "https://public-ui.github.io/en/docs"
+	},
+	"preview.component.link-button.label": {
+		"message": "LinkButton"
+	},
 	"preview.component.progress.label": {
 		"message": "Progress"
 	},

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/link-button.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/link-button.mdx
@@ -4,9 +4,8 @@ description: Description, specification and examples for the LinkButton componen
 ---
 
 import Readme from '/readmes/link-button/readme.md';
-import { Configurator } from '@site/src/components/Configurator';
-import { LiveEditorCompact } from '@site/src/components/LiveEditorCompact';
 import { ExampleLink } from '@site/src/components/ExampleLink';
+import LinkButtonPreview from '@site/src/components/previews/components/LinkButton';
 
 # LinkButton
 
@@ -15,15 +14,11 @@ For more information about the appearance, see the <kol-link _href="../component
 
 ## Construction
 
-### Code
-
-```html
-<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-<kol-link-button _href="#" _label="Secondary" _variant="danger"></kol-link-button>
-<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_label', '_href', '_variant', '_disabled']}
+	codeCollapsable
+	codeCollapsed
+/>
 
 ### Events
 
@@ -33,24 +28,10 @@ For the handling of events or callbacks, see <kol-link _label="Events" _href="..
 |---------|-----------------------|------------------|
 | `click` | Element is clicked | `_href` property |
 
-### Example
-
-<div class="flex gap-2">
-	<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-	<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-	<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-	<kol-link-button _href="#" _label="Danger" _variant="danger"></kol-link-button>
-	<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-</div>
+# API
 
 <Readme />
 
-<ExampleLink component="link-button" />
-
-## Live editor
-
-<LiveEditorCompact component="link-button" />
-
 ## Examples
 
-<Configurator component="link-button" sample="basic" />
+<ExampleLink component="link-button" />

--- a/src/components/previews/components/LinkButton.tsx
+++ b/src/components/previews/components/LinkButton.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Preview, { PreviewLayout } from '../Preview';
+import { BooleanProperty, AlignProperty, IconsProperty, ButtonVariantProperty } from '../properties';
+import type { JSX } from '@public-ui/components';
+import { KolInputText, KolLinkButton } from '@public-ui/react-v19';
+import { translate } from '@docusaurus/Translate';
+
+interface LinkButtonPreviewProps {
+    initialProps?: JSX.KolLinkButton;
+    visibleProperties?: (keyof JSX.KolLinkButton)[];
+    codeCollapsable?: boolean;
+    codeCollapsed?: boolean;
+}
+
+const LinkButtonPreview = (props: LinkButtonPreviewProps) => {
+    const defaultProps = React.useMemo<JSX.KolLinkButton>(
+        () => ({
+            _label: translate({ id: 'preview.component.link-button.label' }),
+            _href: translate({ id: 'preview.component.link-button.href' }),
+            _variant: 'primary',
+        }),
+        [],
+    );
+
+    return (
+        <Preview<JSX.KolLinkButton>
+            propertyComponents={{
+                _label: <KolInputText _label="Label" />,
+                _href: <KolInputText _label="Href" />,
+                _variant: <ButtonVariantProperty label="Variant" defaultValue="primary" />,
+                _target: <KolInputText _label="Target" />,
+                _icons: <IconsProperty label="Icons" />,
+                _tooltipAlign: <AlignProperty label="Tooltip Align" defaultValue="top" />,
+                _disabled: <BooleanProperty label="Disabled" />,
+                _hideLabel: <BooleanProperty label="Hide Label" />,
+                _download: <KolInputText _label="Download" />,
+                _accessKey: <KolInputText _label="Access Key" />,
+                _ariaControls: <KolInputText _label="ARIA Controls" />,
+                _ariaDescription: <KolInputText _label="ARIA Description" />,
+                _customClass: <KolInputText _label="Custom Class" />,
+                _shortKey: <KolInputText _label="Short Key" _maxLength={1} />,
+            }}
+            initialProps={{ ...defaultProps, ...props.initialProps }}
+            componentName="KolLinkButton"
+            visibleProperties={props.visibleProperties}
+            codeCollapsable={props.codeCollapsable}
+            codeCollapsed={props.codeCollapsed}
+            layout={PreviewLayout.CENTERED}
+        >
+            {(componentProps) => <KolLinkButton {...componentProps} />}
+        </Preview>
+    );
+};
+
+export default LinkButtonPreview;

--- a/src/components/previews/components/LinkButton.tsx
+++ b/src/components/previews/components/LinkButton.tsx
@@ -34,7 +34,7 @@ const LinkButtonPreview = (props: LinkButtonPreviewProps) => {
                 _disabled: <BooleanProperty label="Disabled" />,
                 _hideLabel: <BooleanProperty label="Hide Label" />,
                 _download: <KolInputText _label="Download" />,
-                _accessKey: <KolInputText _label="Access Key" />,
+                _accessKey: <KolInputText _label="Access Key" _maxLength={1} />,
                 _ariaControls: <KolInputText _label="ARIA Controls" />,
                 _ariaDescription: <KolInputText _label="ARIA Description" />,
                 _customClass: <KolInputText _label="Custom Class" />,


### PR DESCRIPTION
This pull request refactors the documentation for the `LinkButton` component in both German and English, replacing static code examples and live editors with a new interactive preview component. It also introduces the `LinkButtonPreview` React component and updates localization files to support it.

**Documentation improvements:**

- Replaced static HTML code examples and the live editor in both `docs/30-components/link-button.mdx` (German) and `i18n/en/docusaurus-plugin-content-docs/current/30-components/link-button.mdx` (English) with the new `<LinkButtonPreview />` component for a more interactive and maintainable experience. [[1]](diffhunk://#diff-a8c226c75bf978e8f04284e6782ce8553d41348f35068140b2ea17f8db9c1821L4-R8) [[2]](diffhunk://#diff-a8c226c75bf978e8f04284e6782ce8553d41348f35068140b2ea17f8db9c1821L23-R21) [[3]](diffhunk://#diff-a8c226c75bf978e8f04284e6782ce8553d41348f35068140b2ea17f8db9c1821L41-R37) [[4]](diffhunk://#diff-ed7100b90be1cda05728bdcde92afa50e1762cba03f920da29e5163b7a7bad91L7-R8) [[5]](diffhunk://#diff-ed7100b90be1cda05728bdcde92afa50e1762cba03f920da29e5163b7a7bad91L18-R21) [[6]](diffhunk://#diff-ed7100b90be1cda05728bdcde92afa50e1762cba03f920da29e5163b7a7bad91L36-R37)

**Component additions:**

- Added `src/components/previews/components/LinkButton.tsx`, which implements the `LinkButtonPreview` React component for rendering interactive previews of the `LinkButton` with configurable properties.

**Localization updates:**

- Updated both German (`i18n/de/code.json`) and English (`i18n/en/code.json`) localization files to add labels and hrefs used by the new preview component. [[1]](diffhunk://#diff-843dfb758d7b1e771402c27ea8873a0a67360e0cce95ad81da05de4da30ef0a6R423-R428) [[2]](diffhunk://#diff-0c0bae8c07bdc0dd60f43dc298550f978d4df831d7525eb9b6bc0fa145c704ecR423-R428)