### PR TITLE
ci: add gh-pages deployment and PR preview workflows

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,0 +1,32 @@
+name: PR-Preview - Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    # Skip this job when the base clone URL may be different from the head clone URL.
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          persist-credentials: true
+
+      - name: Remove PR preview folder
+        run: |
+          PR_FOLDER="pr-${{ github.event.pull_request.number }}"
+          if [ -d "$PR_FOLDER" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PR_FOLDER"
+            git commit -m "chore: remove preview for PR #${{ github.event.pull_request.number }}"
+            git push
+          else
+            echo "No preview folder found for PR #${{ github.event.pull_request.number }}, skipping."
+          fi

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -1,0 +1,61 @@
+name: PR Preview - Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: 'workflow-${{ github.workflow }}-${{ github.event.pull_request.number }}'
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Build Artifacts
+        uses: ./.github/actions/build-artifacts
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add .nojekyll
+        run: touch build/.nojekyll
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build
+          target-folder: pr-${{ github.event.pull_request.number }}/${{ steps.sha.outputs.short }}
+          branch: gh-pages
+          clean: false
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- gh-pages-preview -->';
+            const pr = context.issue.number;
+            const sha = '${{ steps.sha.outputs.short }}';
+            const url = `https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-${pr}/${sha}/`;
+            const body = `${marker}\n🚀 Preview deployed to GitHub Pages: [${url}](${url})\nCommit: \`${sha}\``;
+            const { owner, repo } = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: pr });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: pr, body });
+            }

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,41 +3,62 @@ name: Update GitHub page
 on:
   push:
     branches:
-      - release/v3
+      - main
+      - release/1
+      - release/2
+      - release/3
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: 'pages'
-  cancel-in-progress: false
+  group: 'workflow-${{ github.workflow }}-${{ github.ref_name }}'
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
-  update:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Resolve deploy target
+        id: target
+        run: |
+          case "${{ github.ref_name }}" in
+            main)       echo "folder=" >> $GITHUB_OUTPUT ;;
+            release/1)  echo "folder=v1" >> $GITHUB_OUTPUT ;;
+            release/2)  echo "folder=v2" >> $GITHUB_OUTPUT ;;
+            release/3)  echo "folder=v3" >> $GITHUB_OUTPUT ;;
+          esac
 
       - name: Build Artifacts
         uses: ./.github/actions/build-artifacts
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v6
+      - name: Add .nojekyll
+        run: touch build/.nojekyll
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v4.0.0
+      - name: Deploy to gh-pages root
+        if: github.ref_name == 'main'
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          path: build
+          folder: build
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            v1/
+            v2/
+            v3/
+            pr-*/
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      - name: Deploy to gh-pages subfolder
+        if: github.ref_name != 'main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: build
+          target-folder: ${{ steps.target.outputs.folder }}
+          branch: gh-pages
+          clean: true


### PR DESCRIPTION
Adds the same gh-pages deployment and PR preview workflows as #697, targeting `release/3`.

## Changes
- `update.yml`: deployt `release/3` nach `v3/` im `gh-pages`-Branch
- `pr-preview-deploy.yml`: deployt PRs nach `pr-{number}/{sha}/`
- `pr-preview-cleanup.yml`: räumt Preview-Ordner beim Schließen eines PRs auf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk83YZYqcNJ1zBmLiUWWeU)_