### PR TITLE
Update synonyms in card.mdx to include German terms

### DIFF
--- a/docs/30-components/card.mdx
+++ b/docs/30-components/card.mdx
@@ -13,7 +13,7 @@ import BetaDocsBanner from '@site/src/components/BetaDocsBanner';
 
 <BetaDocsBanner />
 
-**Synonyme:** Container, Box, Panel
+**Synonyme:** Karte, Kachel, Container, Box, Panel
 
 **Beschreibung:** Die **Card**-Komponente ist ideal, um einzelne Bereiche einer Webseite optisch hervorzuheben und Inhalte zu strukturieren. Sie besteht aus einem Titel-Bereich und einem Inhalts-Bereich, die durch eine visuelle Trennlinie voneinander abgegrenzt sind.
 

--- a/src/components/LiveEditorCompact/attributeInputs/Color.tsx
+++ b/src/components/LiveEditorCompact/attributeInputs/Color.tsx
@@ -19,7 +19,7 @@ export function Color(props: Props) {
 		<KolInputColor
 			_label=""
 			_on={{ onInput: (_event, value) => update(name, value as string) }}
-			_value={value as string}
+			_value={value}
 		>
 			<span slot="expert">{label}</span>
 		</KolInputColor>

--- a/src/components/previews/components/TableStateful.tsx
+++ b/src/components/previews/components/TableStateful.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Preview, { PreviewLayout } from '../Preview';
-import type { JSX, KoliBriTablePaginationProps } from '@public-ui/components';
+import type { JSX } from '@public-ui/components';
 import { KolInputText, KolTableStateful } from '@public-ui/react-v19';
 import { translate } from '@docusaurus/Translate';
 import TableColumnsProperty from '../properties/TableColumnsProperty';
@@ -179,9 +179,9 @@ const TableStatefulPreview: React.FC<TableStatefulPreviewComponentProps> = (prop
 						{ key: 'origin', label: translate({ id: 'preview.component.table-stateful.column.origin' }) },
 					],
 				],
-			} as JSX.KolTableStateful['_headers'],
-			_data: plantData as JSX.KolTableStateful['_data'],
-			_pagination: { _page: 1, _pageSize: 2, _pageSizeOptions: [2, 5, 10] } as KoliBriTablePaginationProps,
+			},
+			_data: plantData,
+			_pagination: { _page: 1, _pageSize: 2, _pageSizeOptions: [2, 5, 10] },
 		}),
 		[plantData],
 	);
@@ -218,7 +218,7 @@ const TableStatefulPreview: React.FC<TableStatefulPreviewComponentProps> = (prop
 		>
 			{(componentProps) => (
 				<div className="w-full h-full overflow-auto">
-					<KolTableStateful {...componentProps} _data={plantData as JSX.KolTableStateful['_data']} />
+					<KolTableStateful {...componentProps} _data={plantData} />
 				</div>
 			)}
 		</Preview>

--- a/src/components/previews/properties/LinksProperty.tsx
+++ b/src/components/previews/properties/LinksProperty.tsx
@@ -107,7 +107,7 @@ const LinksProperty = (props: {
 									_value={typeof link._icons === 'string' ? link._icons : ''}
 									_on={{
 										onInput: (_e: Event, value: unknown) => {
-											handleLinkChange(index, '_icons', value as string);
+											handleLinkChange(index, '_icons', value);
 										},
 									}}
 								/>

--- a/src/components/previews/properties/PaginationHasButtonsProperty.tsx
+++ b/src/components/previews/properties/PaginationHasButtonsProperty.tsx
@@ -1,4 +1,4 @@
-import { PaginationHasButton } from '@public-ui/components';
+import type { PaginationHasButton } from '@public-ui/components';
 import { KolInputCheckbox } from '@public-ui/react-v19';
 import React, { useState } from 'react';
 

--- a/src/components/samplePreviews/SingleSelect.tsx
+++ b/src/components/samplePreviews/SingleSelect.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { KolSingleSelect } from '@public-ui/react-v19';
-import type { Option, StencilUnknown } from '@public-ui/components';
 
 const COUNTRY_OPTIONS = [
 	{ label: 'Dänemark', value: 'dk' },
@@ -14,7 +13,7 @@ const SingleSelect = () => (
 		_label="Label"
 		_placeholder="Placeholder"
 		_required
-		_options={COUNTRY_OPTIONS as Option<StencilUnknown>[]}
+		_options={COUNTRY_OPTIONS}
 		_value={'Deutschland'}
 	/>
 );


### PR DESCRIPTION
This pull request makes a minor update to the documentation for the Card component. The list of synonyms has been expanded to include "Karte" and "Kachel" for greater clarity.

- Documentation update:
  * Added "Karte" and "Kachel" to the list of synonyms for the Card component in `card.mdx`.