### PR TITLE
Document known screen reader issues with empty date input fields

### DIFF
--- a/docs/91-known-issues.mdx
+++ b/docs/91-known-issues.mdx
@@ -85,6 +85,22 @@ Die Komponenten InputNumber und InputDate rendern die jeweiligen nativen HTML-El
 
 ### kol-input-date
 
+#### Screenreader lesen leere Datumsfelder mit unerwarteten Rollenbezeichnungen vor
+
+Das native HTML-Element `<input type="date">` besteht intern aus drei Spin-Button-Segmenten
+für Tag, Monat und Jahr (ARIA-Rolle `spinbutton`). Wenn das Feld leer ist, erhalten diese
+Segmente vom Browser den Wert `0`. Screenreader geben diesen Wert zusammen mit ihrer
+jeweiligen Übersetzung der Rolle aus, was zu unerwarteten Ansagen führt:
+
+- **NVDA in Chrome**: Jedes Teilfeld wird als „Drehschalter 0" angesagt.
+- **NVDA in Firefox**: Jedes Teilfeld wird als „Drehschalter" (ohne Wert) angesagt.
+- **VoiceOver in Safari**: Jedes Teilfeld wird als „Stepper" angesagt.
+
+Da die internen Segmente des nativen Date-Inputs vom Browser gerendert werden und über das
+DOM nicht zugänglich sind, ist eine Anpassung der Ausgabe durch KoliBri nicht möglich.
+
+[🐞 GitHub Issue #427](https://github.com/public-ui/public-ui.github.io/issues/427)
+
 #### VoiceOver liest Datumsfelder mit Prozentangabe in Google Chrome vor
 
 In Google Chrome liest VoiceOver bei leeren `date`-Eingabefeldern (ohne Anfangswert) einen unerwarteten Prozentwert zusammen mit der üblichen Eingabeaufforderung vor.

--- a/i18n/en/docusaurus-plugin-content-docs/current/91-known-issues.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/91-known-issues.mdx
@@ -88,6 +88,22 @@ When focusing the element, it's expected that the `readonly` attribute is announ
 
 ### kol-input-date
 
+#### Screen readers announce empty date fields with unexpected role labels
+
+The native HTML element `<input type="date">` consists internally of three spin button segments
+for day, month, and year (ARIA role `spinbutton`). When the field is empty, the browser assigns
+these segments the value `0`. Screen readers announce this value together with their respective
+translation of the role, resulting in unexpected announcements:
+
+- **NVDA in Chrome**: Each segment is announced as "spin button 0".
+- **NVDA in Firefox**: Each segment is announced as "spin button" (without a value).
+- **VoiceOver in Safari**: Each segment is announced as "stepper".
+
+Since the internal segments of the native date input are rendered by the browser and are not
+accessible via the DOM, KoliBri is unable to modify the announced output.
+
+[🐞 GitHub Issue #427](https://github.com/public-ui/public-ui.github.io/issues/427)
+
 #### VoiceOver Reads Date Inputs with Percentage in Google Chrome
 
 In Google Chrome, when using VoiceOver with empty `date` input fields (no initial value), an unexpected percentage value is read aloud alongside the usual prompt.


### PR DESCRIPTION
This pull request updates the known issues documentation for the `kol-input-date` component by adding a new accessibility note about how screen readers announce empty date fields. The update is provided in both the German and English documentation.

Accessibility documentation improvements:

* Added a new section describing how different screen readers (NVDA and VoiceOver) announce empty native `<input type="date">` fields, including unexpected role labels and values, and clarified that this behavior cannot be changed by KoliBri due to browser limitations. [[1]](diffhunk://#diff-6a63230d8af54efbd4e938d70f8e763513d0bf492661720c6c8b3e38fbd32d36R88-R103) [[2]](diffhunk://#diff-6465001e917d7af502ccdca9db892b41fa43547094f93d6d12631107c324d397R91-R106)
* Linked to the related GitHub issue (#427) for further reference. [[1]](diffhunk://#diff-6a63230d8af54efbd4e938d70f8e763513d0bf492661720c6c8b3e38fbd32d36R88-R103) [[2]](diffhunk://#diff-6465001e917d7af502ccdca9db892b41fa43547094f93d6d12631107c324d397R91-R106)