### PR TITLE
Feature/badge synonym doku

### DIFF
--- a/docs/30-components/badge.mdx
+++ b/docs/30-components/badge.mdx
@@ -12,7 +12,7 @@ import BetaDocsBanner from '@site/src/components/BetaDocsBanner';
 
 <BetaDocsBanner />
 
-**Synonyme:** Beschriftung, Status-Anzeige, Label
+**Synonyme:** Beschriftung, Status-Anzeige, Tag, Chip, Pill, Label
 
 **Beschreibung:** Die **Badge**-Komponente hebt bestimmte Informationen optisch hervor. Sie unterstützt die Angabe einer Hintergrundfarbe mit automatischer Berechnung der Textfarbe für optimalen Kontrast, die optionale Hinzufügung eines Icons und eine flexible Gestaltung durch externe CSS-Anpassungen.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/badge.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/badge.mdx
@@ -14,7 +14,9 @@ import BetaDocsBanner from '@site/src/components/BetaDocsBanner';
 
 <BetaDocsBanner />
 
-With **Badges** you can visually highlight certain information on your website.
+**Synonyms:** Status Indicator, Tag, Chip, Pill, Label
+
+**Description:** With **Badges** you can visually highlight certain information on your website.
 In addition to specifying the background color and automatically calculating the text color, KoliBri also offers the option of giving a badge an icon and/or a different font style.
 
 <BadgePreview


### PR DESCRIPTION
This pull request updates the documentation for the Badge component to provide a more comprehensive list of synonyms and enhance clarity in both the German and English documentation.

**Documentation improvements:**

* Expanded the list of synonyms for the Badge component to include "Tag", "Chip", and "Pill" in both the German (`badge.mdx`) and English (`badge.mdx`) documentation files. [[1]](diffhunk://#diff-56565d483095c386fee974a90ba50b445842ea488a173bd2cb2bf3083cf6ac26L15-R15) [[2]](diffhunk://#diff-aa08f3de303470889bf762b2a07324232e3b78344e59c02761441b04a42af64cL17-R19)
* Improved the English description by moving the synonyms into a dedicated line and clarifying the Badge component's capabilities.