### PR TITLE
Feature/min max behavior docs

### DIFF
--- a/docs/30-components/input-date.mdx
+++ b/docs/30-components/input-date.mdx
@@ -58,7 +58,7 @@ Standard-Datumsfeld mit dem Typ `date`. Die Eingabe erfolgt über direkte Zahlen
 ### Best Practices / Empfehlungen
 
 - **Sinnvolle Felder kennzeichnen**: Nutzen Sie `_required`, um Pflichtfelder deutlich zu machen.
-- **Validierung mit `_min` und `_max`**: Begrenzen Sie den gültigen Datumsbereich z. B. für Geburtsdaten oder Terminreservierungen.
+- **Validierung mit `_min` und `_max`**: Begrenzen Sie den gültigen Datumsbereich z. B. für Geburtsdaten oder Terminreservierungen – wirkt nur bei Auswahl über die Steuerelemente, nicht bei manueller Texteingabe.
 - **Korrekt benennen**: Stellen Sie sicher, dass `_name` und `_id` korrekt gesetzt sind für Formularübermittlung.
 - **Hinweistexte nutzen**: Verwenden Sie `_hint` für Angaben zum erwarteten Format oder Einschränkungen.
 - **Browserunterschiede kommunizieren**: Machen Sie Nutzer:innen auf das Firefox-Verhalten bei `month`, `time` und `week` aufmerksam, falls diese Typen verwendet werden.
@@ -120,7 +120,7 @@ Das Attribut `_type` bestimmt das Format und den Auswahldialog:
 
 #### Bereichsbeschränkung
 
-Die Attribute `_min` und `_max` definieren den gültigen Datumsbereich:
+Die Attribute `_min` und `_max` definieren den gültigen Datumsbereich. Sie greifen zuverlässig nur bei der Auswahl über den Kalenderdialog (Datepicker). Bei manueller Texteingabe kann ein Wert außerhalb des definierten Bereichs eingegeben werden, ohne dass automatisch eine Korrektur oder Fehlermeldung erfolgt. Die Validierung manueller Eingaben liegt in der Verantwortung der einbindenden Anwendung.
 
 <InputDatePreview
 	visibleProperties={['_min', '_max']}

--- a/docs/30-components/input-number.mdx
+++ b/docs/30-components/input-number.mdx
@@ -56,7 +56,7 @@ Die **InputNumber**-Komponente wurde mit Fokus auf Barrierefreiheit entwickelt:
 
 ### Best Practices / Empfehlungen
 
-- **Sinnvolle Grenzen setzen**: Verwenden Sie `_min` und `_max`, um Wertbereiche zu definieren. Dies verbessert sowohl die Nutzererfahrung als auch die Datenvalidierung.
+- **Sinnvolle Grenzen setzen**: Verwenden Sie `_min` und `_max`, um Wertbereiche zu definieren – wirkt nur bei Auswahl über die Steuerelemente, nicht bei manueller Texteingabe.
 - **Schrittweite konfigurieren**: Nutzen Sie `_step`, um die Inkrement-Größe bei Pfeiltasten-Navigation festzulegen. Beispiel: `_step="5"` für 5er-Schritte.
 - **Alternative zu direkter Eingabe**: Bieten Sie bei großen Wertbereichen Pfeiltasten oder Spinner-Buttons als visuelle Alternativen zur Direkteingabe an.
 - **Name und ID**: Achten Sie darauf, `_name` und eine eindeutige `_id` korrekt zu setzen, damit die Daten beim Formularabsenden mitgesendet werden.
@@ -141,7 +141,7 @@ Unterstützung für Hinweistexte und Validierungsmeldungen:
 
 #### Numerische Beschränkungen
 
-Konfigurieren Sie Minimal-, Maximalwerte und Schrittweite:
+Konfigurieren Sie Minimal-, Maximalwerte und Schrittweite. `_min` und `_max` greifen zuverlässig nur bei der Auswahl über den Steuerelemente. Bei manueller Texteingabe kann ein Wert außerhalb des definierten Bereichs eingegeben werden, ohne dass automatisch eine Korrektur oder Fehlermeldung erfolgt. Die Validierung manueller Eingaben liegt in der Verantwortung der einbindenden Anwendung.
 
 <InputNumberPreview
 	visibleProperties={['_label', '_min', '_max', '_step']}

--- a/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-date.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/30-components/input-date.mdx
@@ -58,7 +58,7 @@ Standard date field with type `date`. Input is done via direct digit entry with 
 ### Best practices / Recommendations
 
 - **Mark required fields clearly**: Use `_required` to clearly mark mandatory fields.
-- **Validation with `_min` and `_max`**: Limit the valid date range e.g. for dates of birth or appointment bookings.
+- **Validation with `_min` and `_max`**: Limit the valid date range e.g. for dates of birth or appointment bookings - only takes effect when selected via the control elements, not with manual text input.
 - **Correct naming**: Ensure `_name` and `_id` are set correctly for form submission.
 - **Use hint texts**: Use `_hint` for information about the expected format or restrictions.
 - **Communicate browser differences**: Inform users about Firefox behavior with `month`, `time`, and `week` if these types are used.
@@ -120,7 +120,7 @@ The `_type` attribute determines the format and selection dialog:
 
 #### Range restriction
 
-The `_min` and `_max` attributes define the valid date range:
+The `_min` and `_max` attributes define the valid date range. They only reliably take effect when a date is selected via the calendar dialog (datepicker). With manual text input, a value outside the defined range can be entered without automatic correction or an error message. Validation of manual input is the responsibility of the consuming application.
 
 <InputDatePreview
 	visibleProperties={['_min', '_max']}


### PR DESCRIPTION
This pull request updates the documentation for the `InputDate` and `InputNumber` components to clarify the behavior of the `_min` and `_max` attributes. The main change is to explain that these attributes only reliably enforce value restrictions when users select values via control elements (e.g., datepicker or spinner), and not when values are entered manually. Manual input validation is now explicitly described as the responsibility of the consuming application.

**Documentation improvements for value range validation:**

* Clarified in both German and English `InputDate` documentation that `_min` and `_max` only enforce restrictions when using control elements, not with manual text input, and that manual input validation must be handled by the application. [[1]](diffhunk://#diff-9225fda7290f67d99bd6ded79e0198ecd2cb084efc9bb1c240eeac8be3d42294L61-R61) [[2]](diffhunk://#diff-9225fda7290f67d99bd6ded79e0198ecd2cb084efc9bb1c240eeac8be3d42294L123-R123) [[3]](diffhunk://#diff-57ec71823df090c37fbd0121c4590ecba8c373d35e0be22b4938f2e653e53b0cL61-R61) [[4]](diffhunk://#diff-57ec71823df090c37fbd0121c4590ecba8c373d35e0be22b4938f2e653e53b0cL123-R123)
* Updated the `InputNumber` documentation to specify that `_min` and `_max` only affect values selected via control elements, not manual entries, and that validation of manual input is the application's responsibility. [[1]](diffhunk://#diff-ce817f0ff548d3c281e706699bc9e2d66e9f38b7a79162f58d40a545452b847dL59-R59) [[2]](diffhunk://#diff-ce817f0ff548d3c281e706699bc9e2d66e9f38b7a79162f58d40a545452b847dL144-R144)