### PR TITLE
747-Previews fuer die LinkButton-Doku gefixed

### DIFF
--- a/docs/30-components/link-button.mdx
+++ b/docs/30-components/link-button.mdx
@@ -5,6 +5,7 @@ description: Beschreibung, Spezifikation und Beispiele für die LinkButton-Kompo
 
 import Readme from '@site/readmes/link-button/readme.md';
 import BetaDocsBanner from '@site/src/components/BetaDocsBanner';
+import LinkButtonPreview from '@site/src/components/previews/components/LinkButton';
 
 # LinkButton
 
@@ -16,15 +17,13 @@ import BetaDocsBanner from '@site/src/components/BetaDocsBanner';
 
 ## Beispiel
 
-Standard-LinkButton mit verschiedenen Varianten:
+Darstellung der Komponente ohne optional gesetzte Felder.:
 
-<div className="flex gap-2 flex-wrap">
-	<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-	<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-	<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-	<kol-link-button _href="#" _label="Danger" _variant="danger"></kol-link-button>
-	<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-</div>
+<LinkButtonPreview
+	visibleProperties={[]}
+	initialProps={{ _label: 'LinkButton' }}
+	codeCollapsable
+/>
 
 ## Barrierefreiheit
 
@@ -85,189 +84,133 @@ LinkButton ist semantisch ein Link mit Button-Styling. <kol-link _href="../compo
 
 ### Playground
 
+<LinkButtonPreview
+	visibleProperties={['_label', '_href', '_variant', '_target', '_icons', '_tooltipAlign', '_disabled', '_hideLabel', '_download', '_accessKey', '_ariaControls', '_ariaCurrentValue', '_ariaDescription', '_customClass', '_shortKey']}
+	initialProps={{ _label: 'LinkButton' }}
+	codeCollapsable
+/>
+
 Erkunden Sie die verschiedenen Konfigurationen der LinkButton-Komponente:
-
-<div className="space-y-4">
-
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Standard LinkButton"
->
-</kol-link-button>
-```
-
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Mit Icon"
-	_icons="fa-solid fa-arrow-right"
->
-</kol-link-button>
-```
-
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="In neuem Tab"
-	_target="_blank"
->
-</kol-link-button>
-```
-
-```html
-<kol-link-button
-	_href="document.pdf"
-	_label="PDF herunterladen"
-	_download="document.pdf"
->
-</kol-link-button>
-```
-
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Deaktiviert"
-	_disabled
->
-</kol-link-button>
-```
-
-</div>
 
 ### Funktionalitäten (mit Code)
 
-#### Basis-Variante
+#### Beschriftung
 
-Standard-LinkButton ohne Styling-Variante:
+Die sichtbare Beschriftung wird über `_label` gesetzt:
 
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Normal"
-	_variant="normal"
->
-</kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_label']}
+	initialProps={{ _label: 'Normal', _href: '#'}}
+	codeCollapsable
+	codeCollapsed
+/>
 
 #### Varianten
 
 Die Darstellung wird über `_variant` gesteuert:
 
-```html
-<kol-link-button _href="#" _label="Primary" _variant="primary"></kol-link-button>
-<kol-link-button _href="#" _label="Secondary" _variant="secondary"></kol-link-button>
-<kol-link-button _href="#" _label="Normal" _variant="normal"></kol-link-button>
-<kol-link-button _href="#" _label="Tertiary" _variant="tertiary"></kol-link-button>
-<kol-link-button _href="#" _label="Danger" _variant="danger"></kol-link-button>
-<kol-link-button _href="#" _label="Ghost" _variant="ghost"></kol-link-button>
-<kol-link-button _href="#" _label="Custom" _variant="custom" _custom-class="custom-style"></kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_variant']}
+	initialProps={{ _label: 'LinkButton', _href: '#', _variant: 'primary'}}
+	codeCollapsable
+	codeCollapsed
+/>
+
+**Verfügbare Varianten:**
+- `primary` – Primäre Handlungsaufforderung (Standard)
+- `secondary` – Sekundäre Aktion
+- `normal` – Standard-Variante
+- `danger` – Gefährliche oder destruktive Aktion
+- `ghost` – Subtile Variante
+- `tertiary` – Tertiäre Aktion
+- `custom` – Benutzerdefinierte Styling (erfordert `_custom-class`)
 
 #### Icons
 
 Icons können über das Attribut `_icons` hinzugefügt werden:
 
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Mit Icon"
-	_icons="fa-solid fa-arrow-right"
->
-</kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_icons', '_tooltipAlign']}
+	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'fa-solid fa-arrow-right'}}
+	codeCollapsable
+	codeCollapsed
+/>
+
+Icons können auch als Objekt mit den Positionen `top`, `right`, `bottom` und `left` angegeben werden, jeweils mit Icon-Klasse oder Styleobjekt.
+
+#### Icon-Only-Button
+
+Mit `_hideLabel` wird nur das Icon angezeigt, die Beschriftung wird als Tooltip angezeigt:
+
+<LinkButtonPreview
+	visibleProperties={['_hideLabel', '_icons']}
+	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'fa-solid fa-arrow-right', _hideLabel: true }}
+	codeCollapsable
+	codeCollapsed
+/>
 
 #### Zielverhalten
 
-Kontrolle darüber, wo der Link öffnet:
+Kontrolle darüber, wie der Link im Browser geöffnet wird:
 
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Im gleichen Tab"
-	_target="_self"
->
-</kol-link-button>
+<LinkButtonPreview
+	visibleProperties={['_target']}
+	initialProps={{ _label: 'LinkButton', _href: '#', _target: '_self'}}
+	codeCollapsable
+	codeCollapsed
+/>
 
-<kol-link-button
-	_href="https://example.com"
-	_label="Im neuen Tab"
-	_target="_blank"
->
-</kol-link-button>
-```
+**Verfügbare Targets:**
+- `_self` – Der Link wird im aktuellen Tab geöffnet (Standard)
+- `_blank` – Der Link wird in einem neuen Tab geöffnet
 
 #### Download-Links
 
 Signalisieren Sie dem Browser, dass eine Datei heruntergeladen werden soll:
 
-```html
-<kol-link-button
-	_href="/files/dokument.pdf"
-	_label="PDF herunterladen"
-	_download="dokument.pdf"
->
-</kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={[]}
+	initialProps={{ _label: 'PDF herunterladen', _href: '/files/dokument.pdf', _download: 'dokument.pdf'}}
+	codeCollapsable
+	codeCollapsed
+/>
 
-#### Zustände
+#### Disabled-Status
 
-Die Komponente unterstützt verschiedene Zustände:
+Mit `_disabled` wird der Button deaktiviert:
 
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Standard"
->
-</kol-link-button>
-
-<kol-link-button
-	_href="https://example.com"
-	_label="Deaktiviert"
-	_disabled
->
-</kol-link-button>
-
-<kol-link-button
-	_href="https://example.com"
-	_label="Mit verstecktem Label"
-	_hide-label
->
-</kol-link-button>
-```
-
-#### ARIA-Attribute
-
-Zusätzliche Accessibility-Informationen:
-
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Aktuelle Seite"
-	_aria-current-value="page"
->
-</kol-link-button>
-
-<kol-link-button
-	_href="https://example.com"
-	_label="Mit Beschreibung"
-	_aria-description="Navigiert zur Dokumentation"
->
-</kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_disabled']}
+	initialProps={{ _label: 'Deaktiviert', _href: '#', _disabled: true }}
+	codeCollapsable
+	codeCollapsed
+/>
 
 #### Tastaturkürzel
 
-Anzeige von Tastaturkürzeln:
+Ein visueller Hinweis auf ein verfügbares Tastaturkürzel:
 
-```html
-<kol-link-button
-	_href="https://example.com"
-	_label="Startseite"
-	_short-key="H"
->
-</kol-link-button>
-```
+<LinkButtonPreview
+	visibleProperties={['_shortKey']}
+	initialProps={{ _label: 'Startseite', _href: '#', _shortKey: 'H' }}
+	codeCollapsable
+	codeCollapsed
+/>
+
+#### ARIA-Attribute
+
+LinkButton mit ARIA-Attributen für erweiterte Semantik:
+
+<LinkButtonPreview
+	initialProps={{
+		_label: 'Aktuelle Seite',
+		_ariaCurrentValue: 'page',
+		_ariaDescription: 'Navigiert zur Dokumentation',
+	}}
+	visibleProperties={['_ariaCurrentValue', '_ariaDescription']}
+	codeCollapsable
+	codeCollapsed
+/>
 
 #### Events
 

--- a/docs/30-components/link-button.mdx
+++ b/docs/30-components/link-button.mdx
@@ -17,13 +17,9 @@ import LinkButtonPreview from '@site/src/components/previews/components/LinkButt
 
 ## Beispiel
 
-Darstellung der Komponente ohne optional gesetzte Felder.:
+Darstellung der Komponente ohne optional gesetzte Felder:
 
-<LinkButtonPreview
-	visibleProperties={[]}
-	initialProps={{ _label: 'LinkButton' }}
-	codeCollapsable
-/>
+<LinkButtonPreview visibleProperties={[]} initialProps={{ _label: 'LinkButton' }} codeCollapsable />
 
 ## Barrierefreiheit
 
@@ -46,10 +42,10 @@ Die **LinkButton**-Komponente wird als Link-Element renders und ist daher vollst
 
 ### Tastatursteuerung
 
-| Taste   | Funktion                          |
-| ------- | --------------------------------- |
-| `Tab`   | Fokussiert die LinkButton.        |
-| `Enter` | Öffnet den Hyperlink.             |
+| Taste   | Funktion                         |
+| ------- | -------------------------------- |
+| `Tab`   | Fokussiert die LinkButton.       |
+| `Enter` | Öffnet den Hyperlink.            |
 | `Space` | Öffnet den Hyperlink (optional). |
 
 ### Best Practices / Empfehlungen
@@ -75,7 +71,7 @@ Die **LinkButton**-Komponente wird als Link-Element renders und ist daher vollst
 Verwenden Sie LinkButton, wenn Sie semantisch einen Link benötigen (Navigation), diesen aber mit Button-Styling betonen möchten. Für echte Aktionen (wie Formularabsendung) verwenden Sie stattdessen einen Button.
 
 **Kann ich LinkButton mit Icons verwenden?**
-Ja, das Attribut `_icons` unterstützt Icon-Klassennamen (z. B. `_icons="fa-solid fa-arrow-right"`).
+Ja, das Attribut `_icons` unterstützt Icon-Klassennamen (z. B. `_icons="kolicon-house"`).
 
 **Was ist der Unterschied zu button-link?**
 LinkButton ist semantisch ein Link mit Button-Styling. <kol-link _href="../components/button-link" _label="ButtonLink"></kol-link> ist dagegen semantisch ein Button mit Link-Styling.
@@ -85,7 +81,23 @@ LinkButton ist semantisch ein Link mit Button-Styling. <kol-link _href="../compo
 ### Playground
 
 <LinkButtonPreview
-	visibleProperties={['_label', '_href', '_variant', '_target', '_icons', '_tooltipAlign', '_disabled', '_hideLabel', '_download', '_accessKey', '_ariaControls', '_ariaCurrentValue', '_ariaDescription', '_customClass', '_shortKey']}
+	visibleProperties={[
+		'_label',
+		'_href',
+		'_variant',
+		'_target',
+		'_icons',
+		'_tooltipAlign',
+		'_disabled',
+		'_hideLabel',
+		'_download',
+		'_accessKey',
+		'_ariaControls',
+		'_ariaCurrentValue',
+		'_ariaDescription',
+		'_customClass',
+		'_shortKey',
+	]}
 	initialProps={{ _label: 'LinkButton' }}
 	codeCollapsable
 />
@@ -100,7 +112,7 @@ Die sichtbare Beschriftung wird über `_label` gesetzt:
 
 <LinkButtonPreview
 	visibleProperties={['_label']}
-	initialProps={{ _label: 'Normal', _href: '#'}}
+	initialProps={{ _label: 'Normal', _href: '#' }}
 	codeCollapsable
 	codeCollapsed
 />
@@ -111,12 +123,13 @@ Die Darstellung wird über `_variant` gesteuert:
 
 <LinkButtonPreview
 	visibleProperties={['_variant']}
-	initialProps={{ _label: 'LinkButton', _href: '#', _variant: 'primary'}}
+	initialProps={{ _label: 'LinkButton', _href: '#', _variant: 'primary' }}
 	codeCollapsable
 	codeCollapsed
 />
 
 **Verfügbare Varianten:**
+
 - `primary` – Primäre Handlungsaufforderung (Standard)
 - `secondary` – Sekundäre Aktion
 - `normal` – Standard-Variante
@@ -131,7 +144,7 @@ Icons können über das Attribut `_icons` hinzugefügt werden:
 
 <LinkButtonPreview
 	visibleProperties={['_icons', '_tooltipAlign']}
-	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'fa-solid fa-arrow-right'}}
+	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'kolicon-house' }}
 	codeCollapsable
 	codeCollapsed
 />
@@ -144,7 +157,7 @@ Mit `_hideLabel` wird nur das Icon angezeigt, die Beschriftung wird als Tooltip 
 
 <LinkButtonPreview
 	visibleProperties={['_hideLabel', '_icons']}
-	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'fa-solid fa-arrow-right', _hideLabel: true }}
+	initialProps={{ _label: 'LinkButton', _href: '#', _icons: 'kolicon-house', _hideLabel: true }}
 	codeCollapsable
 	codeCollapsed
 />
@@ -155,12 +168,13 @@ Kontrolle darüber, wie der Link im Browser geöffnet wird:
 
 <LinkButtonPreview
 	visibleProperties={['_target']}
-	initialProps={{ _label: 'LinkButton', _href: '#', _target: '_self'}}
+	initialProps={{ _label: 'LinkButton', _href: '#', _target: '_self' }}
 	codeCollapsable
 	codeCollapsed
 />
 
 **Verfügbare Targets:**
+
 - `_self` – Der Link wird im aktuellen Tab geöffnet (Standard)
 - `_blank` – Der Link wird in einem neuen Tab geöffnet
 
@@ -170,7 +184,7 @@ Signalisieren Sie dem Browser, dass eine Datei heruntergeladen werden soll:
 
 <LinkButtonPreview
 	visibleProperties={[]}
-	initialProps={{ _label: 'PDF herunterladen', _href: '/files/dokument.pdf', _download: 'dokument.pdf'}}
+	initialProps={{ _label: 'PDF herunterladen', _href: '/files/dokument.pdf', _download: 'dokument.pdf' }}
 	codeCollapsable
 	codeCollapsed
 />
@@ -216,9 +230,9 @@ LinkButton mit ARIA-Attributen für erweiterte Semantik:
 
 Zur Behandlung von Events bzw. Callbacks siehe <kol-link _label="Events" _href="../concepts/events" />.
 
-| Event   | Auslöser                | Value         |
-| ------- | ----------------------- | ------------- |
-| `click` | Element wird angeklickt | `_href`-Wert  |
+| Event   | Auslöser                | Value        |
+| ------- | ----------------------- | ------------ |
+| `click` | Element wird angeklickt | `_href`-Wert |
 
 ## API
 

--- a/src/components/previews/components/LinkButton.tsx
+++ b/src/components/previews/components/LinkButton.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Preview, { PreviewLayout } from '../Preview';
 import { BooleanProperty, AlignProperty, IconsProperty, ButtonVariantProperty } from '../properties';
 import type { JSX } from '@public-ui/components';
-import { KolInputText, KolLinkButton } from '@public-ui/react-v19';
+import { KolInputText, KolLinkButton, KolSelect } from '@public-ui/react-v19';
 import { translate } from '@docusaurus/Translate';
 
 interface LinkButtonPreviewProps {
@@ -28,7 +28,15 @@ const LinkButtonPreview = (props: LinkButtonPreviewProps) => {
                 _label: <KolInputText _label="Label" />,
                 _href: <KolInputText _label="Href" />,
                 _variant: <ButtonVariantProperty label="Variant" defaultValue="primary" />,
-                _target: <KolInputText _label="Target" />,
+                _target: (
+					<KolSelect
+						_label="Target"
+						_options={[
+							{ label: '_self', value: '_self' },
+							{ label: '_blank', value: '_blank' },
+						]}
+					/>
+				),
                 _icons: <IconsProperty label="Icons" />,
                 _tooltipAlign: <AlignProperty label="Tooltip Align" defaultValue="top" />,
                 _disabled: <BooleanProperty label="Disabled" />,
@@ -36,6 +44,7 @@ const LinkButtonPreview = (props: LinkButtonPreviewProps) => {
                 _download: <KolInputText _label="Download" />,
                 _accessKey: <KolInputText _label="Access Key" _maxLength={1} />,
                 _ariaControls: <KolInputText _label="ARIA Controls" />,
+                _ariaCurrentValue: <KolInputText _label="ARIA Current Value" />,
                 _ariaDescription: <KolInputText _label="ARIA Description" />,
                 _customClass: <KolInputText _label="Custom Class" />,
                 _shortKey: <KolInputText _label="Short Key" _maxLength={1} />,


### PR DESCRIPTION
Previews in link-button.mdx ergaenzt und entsprechende html-Elemente entfernt.
LinkButton.tsx handling von _target angepasst und _ariaCurrentValue aufgenommen.