### PR TITLE
docs: improve Vite+Vue getting started guide

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -152,13 +152,15 @@ export const AppComponent = () => {
 
 #### 2. Plugin
 
+In diesem Schritt registrieren Sie die KoliBri-Komponenten und das Theme bei der Vue-App. Legen Sie dazu eine Datei `kolibri.plugin.ts` an, die ein Vue-Plugin exportiert. Das Plugin ruft `register()` auf, um das Theme zu setzen und die Web Components asynchron (lazy) nachzuladen, sobald sie verwendet werden.
+
 kolibri.plugin.ts
 
 ```js
 import type { Plugin } from 'vue';
 import { defineCustomElements } from '@public-ui/components/loader';
 import { register } from '@public-ui/components';
-import { DEFAULT } from '@public-ui/theme-default';
+import { DEFAULT } from '@public-ui/themes';
 export const ComponentLibrary: Plugin = {
 	install() {
 		register(DEFAULT, defineCustomElements)
@@ -174,7 +176,7 @@ main.ts:
 import { createApp } from 'vue'
 import App from './App.vue'
 import './assets/main.css'
-+ import { ComponentLibrary } from './vue.plugin'
++ import { ComponentLibrary } from './kolibri.plugin'
 
 const app = createApp(App)
 
@@ -237,12 +239,19 @@ export default defineConfig({
 
 #### 5. Beispiel
 
-```html
-<KolInputText :_value="text" :_on="{ onChange: (e: unknown, v: string) => (text = v) }"></KolInputText>
-<KolButton _label="Text löschen" :_on="{ onClick: () => (text = '') }"></KolButton>
-```
+Um eine KoliBri-Komponente zu verwenden, importieren Sie diese aus dem Vue-Adapter und binden sie als Tag ein. Die Komponenten werden in PascalCase (`KolButton`) importiert und im Template verwendet.
 
-Hinweis: KoliBri-Inputs übergeben in der Regel das Ursprungsevent als ersten Parameter und den Wert des Feldes als Zweiten.
+App.vue
+
+```vue
+<script setup lang="ts">
+import { KolButton } from '@public-ui/vue';
+</script>
+
+<template>
+	<KolButton _label="Klick mich" />
+</template>
+```
 
 ### III React
 


### PR DESCRIPTION
## Summary

Verbessert den Abschnitt **II Vite + Vue** auf der [Getting Started](https://public-ui.github.io/docs/get-started/first-steps#ii-vite--vue) Seite, basierend auf dem Feedback in #769.

### Probleme aus dem Ticket

- [x] **Erklärung für `kolibri.plugin.ts` fehlt** — Ein Satz hinzugefügt, der erklärt, was die Datei macht (Registrierung der Komponenten und des Themes als Vue-Plugin).
- [x] **Imports fehlen im Beispiel** — Das neue Beispiel enthält den vollständigen `import` der Komponente aus `@public-ui/vue`.
- [x] **Beispiel zu kompliziert** — Statt `KolInputText` + `KolButton` mit Two-Way-Binding jetzt ein einzelner `KolButton` mit Label.

### Weitere gefundene Fehler (Root Cause für \u201eComponents sehen nicht aus wie in der Doku\u201c)

- **Falscher Theme-Import:** `@public-ui/theme-default` \u2192 `@public-ui/themes`. In Schritt 1 wird `@public-ui/themes` installiert, der Import verwies aber auf ein anderes Paket. Das ist der Grund, warum das Theme fehlte.
- **Falscher Dateiname im main.ts-Import:** `'./vue.plugin'` \u2192 `'./kolibri.plugin'` (Datei heißt `kolibri.plugin.ts`).

## Test Plan

- [x] `pnpm run lint` bestanden
- [x] `pnpm run build` bestanden
- [ ] Vue-Setup anhand der Doku einmal durchspielen

Closes #769