### PR TITLE
docs: redesign getting started page as streamlined 1-pager

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -3,13 +3,41 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 # Erste Schritte
 
 <KolAlert _type="warning" _variant="card">
-	Für Projekt im ITZBund gibt es ein vorgegebenes Seed-Projekt, welches über die internen Kommunikationswege angefragt
+	Für Projekte im ITZBund gibt es ein vorgegebenes Seed-Projekt, welches über die internen Kommunikationswege angefragt
 	werden kann.
 </KolAlert>
 
-## Neues Projekt erstellen
+**KoliBri** ist eine Bibliothek für barrierefreie Web Components. Die Komponenten sind framework-unabhängig und können
+in nahezu jedem webbasierten Projekt verwendet werden. Diese Seite gibt einen kompakten Überblick, wie Sie starten.
 
-Ein neues Projekt kann mit Hilfe des Kommandozeilenassistenten schnell erstellt werden.
+## Technologien
+
+KoliBri wird in der öffentlichen <KolLink _label="NPM-Registry" _href="https://www.npmjs.com/search?q=%40public-ui" _target="_blank" /> versioniert bereitgestellt.
+Die Komponenten basieren auf dem **Web Components Standard** und können daher in jedem modernen Webprojekt eingesetzt werden.
+
+Zusätzlich bieten wir für gängige Frameworks eigene **Adapter** an, die eine nahtlose Integration mit voller Typ-Unterstützung
+und Autovervollständigung ermöglichen:
+
+| Adapter                  | Framework                          |
+| ------------------------ | ---------------------------------- |
+| `@public-ui/react-v19`   | React (empfohlen für JSX/TSX)      |
+| `@public-ui/solid`       | Solid                              |
+| `@public-ui/vue`         | Vue                                |
+| `@public-ui/preact`      | Preact (experimentell)             |
+| `@public-ui/angular-v19` | Angular v19                        |
+| `@public-ui/angular-v20` | Angular v20                        |
+| `@public-ui/angular-v21` | Angular v21                        |
+| `@public-ui/hydrate`     | Server-Side-Rendering (SSR)        |
+
+Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden.
+Weitere Details finden Sie auf der Seite <KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
+
+## Projekt aus Vorlagen erstellen
+
+Der schnellste Weg zu einem lauffähigen KoliBri-Projekt ist das <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
+Es enthält vorgefertigte Starter-Templates für gängige Frameworks und Rendering-Varianten.
+
+### Mit dem Kommandozeilenassistenten
 
 ```
 npm init kolibri@latest my-kolibri-app
@@ -20,380 +48,69 @@ npm init kolibri@latest my-kolibri-app
 	alt="Zeigt wie man mit create-kolibri eine neue App anlegen kann."
 />
 
-## Einbinden in ein bestehendes Projekt
+### Direkt aus einem Template (degit)
 
-### Einbinden von Schriftarten
+Alternativ kann ein Template direkt aus dem Repository geklont werden. Ersetzen Sie `<framework>` durch den
+gewünschten Template-Namen:
 
-Schriftarten werden von Natur aus losgelöst vom CSS geladen und müssen je nach **KoliBri**-Theme in die projektspezifische Rahmenseite (`index.html`) eingebunden werden.
+| Framework | Template                           |
+| --------- | ---------------------------------- |
+| Angular   | `csr/angular`                      |
+| React     | `csr/react-vite` (empfohlen)       |
+| Vue       | `csr/vue-vite`                     |
+| Statisch  | `csr/static-page`                  |
 
-Hierzu können die in der Bibliothek mitgelieferten Schriftarten in die eigenen Assets kopiert werden: `node_modules/@public-ui/themes/assets`, oder eigene verwendet werden.
-
-Bitte importieren Sie nur die Schriftarten und Icons, die Sie verwenden, um unnötigen Datentransfer zu vermeiden.
-
-```html
-<!DOCTYPE html>
-<html lang="de" dir="ltr">
-	<head>
-		<title>Webapplication | KoliBri</title>
-		<meta charset="UTF-8" />
-		<meta name="description" content="..." />
-		<base href="/" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<link rel="shortcut icon" type="image/x-icon" href="assets/kolibri.ico" />
-		<link rel="stylesheet" href="assets/bundes/style.css" />
-		<link rel="stylesheet" href="assets/kolicons/style.css" />
-		<link rel="stylesheet" href="assets/fontawesome-free/css/all.min.css" />
-		<link rel="stylesheet" href="assets/icofont/icofont.min.css" />
-		<link rel="stylesheet" href="assets/kreon/style.css" />
-		<link rel="stylesheet" href="assets/noto-sans/noto-sans.css" />
-		<link rel="stylesheet" href="assets/material-icons/iconfont/material-icons.css" />
-		<link rel="stylesheet" href="assets/material-symbols/index.css" />
-		<link rel="stylesheet" href="assets/roboto/roboto.css" />
-		<link rel="stylesheet" href="assets/tabler-icons/tabler-icons.css" />
-	</head>
-</html>
+```bash
+npx degit public-ui/templates/<framework> my-kolibri-project
+cd my-kolibri-project
+npm i # oder pnpm i oder yarn
 ```
 
-### Typescript
+Die vollständige Liste aller Templates — inklusive SSR (Express) und Theme-Vorlagen — finden Sie im
+<KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates#available-templates" _target="_blank" />.
 
-Um eine umfängliche Codevervollständigung zu erhalten, benötigen Sie folgenden Eintrag in der `tsconfig.json`:
+## Themes
 
-```json
-{
-  "compilerOptions": {
-		...
-    "moduleResolution": "Node",
-		...
-  },
-	...
-}
-```
+KoliBri liefert die Komponenten **ohne festes Styling** aus. Das visuelle Erscheinungsbild wird über ein **Theme**
+bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/themes` enthält mehrere vorgefertigte Themes:
 
-### I Vite + React
+| Theme       | Export       | Beschreibung                                        |
+| ----------- | ------------ | --------------------------------------------------- |
+| Default     | `DEFAULT`    | Das Standard-Theme von KoliBri                      |
+| BWSt        | `BWSt`       | Theme der Baustatistik (Baustatistik-Vorschrift)    |
+| Desy        | `DesyV11`    | Design-System Theme                                 |
+| ECL (EC)    | `ECL_EC`     | European Commission Theme                           |
+| ECL (EU)    | `ECL_EU`     | European Union Theme                                |
+| KERN        | `KERN_V2`    | KERN Design-System Theme                            |
 
-#### 1. Installieren der KoliBri-Bibliotheken
+### Theme registrieren und umschalten
 
-<kol-tabs _headers="['npm', 'pnpm', 'yarn']" _tabs='[{"_label":"NPM"},{"_label":"PNPM"},{"_label":"YARN"}]'>
-	<div>npm i @public-ui/components @public-ui/themes @public-ui/react</div>
-	<div>pnpm i @public-ui/components @public-ui/themes @public-ui/react</div>
-	<div>yarn add @public-ui/components @public-ui/themes @public-ui/react</div>
-</kol-tabs>
+Das Theme wird beim Aufruf von `register()` als erster Parameter übergeben. Um zur Laufzeit zwischen
+mehreren Themes zu wechseln, können Sie ein Array von Themes übergeben und die Auswahl per Schalter steuern.
 
-#### 2. Integration
-
-main.tsx
-
-```diff
-import React from "react";
-import ReactDOM from "react-dom/client";
-import App from "./App.tsx";
-import "./index.css";
-
-+import { register } from "@public-ui/components";
-+import { defineCustomElements } from "@public-ui/components/loader";
-+import { DEFAULT } from "@public-ui/themes";
-
-+register(DEFAULT, defineCustomElements)
-+  .then(() => {
-    ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-      <React.StrictMode>
-        <App />
-      </React.StrictMode>
-    );
-+  })
-+  .catch(console.warn);
-```
-
-#### 3. Modul einbinden
-
-index.html
-
-```diff
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-+   <script type="module" src="/node_modules/@public-ui/components/dist/kolibri/kolibri.esm.js"></script>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
-</html>
-```
-
-#### 4. Beispiel
-
-```tsx
-import React from 'react';
-import { KolSpin } from '@public-ui/react-v19';
-
-export const AppComponent = () => {
-	return (
-		<div>
-			<KolSpin _show />
-		</div>
-	);
-};
-```
-
-### II Vite + Vue
-
-#### 1. Installieren der KoliBri-Bibliotheken
-
-<kol-tabs _headers="['npm', 'pnpm', 'yarn']" _tabs='[{"_label":"NPM"},{"_label":"PNPM"},{"_label":"YARN"}]'>
-	<div>npm i @public-ui/components @public-ui/themes @public-ui/vue</div>
-	<div>pnpm i @public-ui/components @public-ui/themes @public-ui/vue</div>
-	<div>yarn add @public-ui/components @public-ui/themes @public-ui/vue</div>
-</kol-tabs>
-
-#### 2. Plugin
-
-kolibri.plugin.ts
-
-```js
-import type { Plugin } from 'vue';
-import { defineCustomElements } from '@public-ui/components/loader';
+```ts
 import { register } from '@public-ui/components';
-import { DEFAULT } from '@public-ui/theme-default';
-export const ComponentLibrary: Plugin = {
-	install() {
-		register(DEFAULT, defineCustomElements)
-			.then(() => console.log('Components registered'))
-			.catch(console.warn);
-	},
-};
-```
-
-main.ts:
-
-```diff
-import { createApp } from 'vue'
-import App from './App.vue'
-import './assets/main.css'
-+ import { ComponentLibrary } from './vue.plugin'
-
-const app = createApp(App)
-
-+ app.use(ComponentLibrary)
-
-app.mount('#app')
-```
-
-#### 3. Modul einbinden
-
-index.html
-
-```diff
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-+   <script type="module" src="/node_modules/@public-ui/components/dist/kolibri/kolibri.esm.js"></script>
-    <title>Vite App</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
-</html>
-```
-
-#### 4. Konfiguration anpassen
-
-vite.config.ts
-
-```diff
-import { fileURLToPath, URL } from 'node:url'
-
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-
-// https://vitejs.dev/config/
-export default defineConfig({
--  plugins: [],
-+  plugins: [
-+    vue({
-+      template: {
-+        compilerOptions: {
-+          // treat all tags with a dash as custom elements
-+          isCustomElement: (tag) => tag.includes('-')
-+        }
-+      }
-+    })
-+  ],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
-    }
-  }
-})
-```
-
-#### 5. Beispiel
-
-```html
-<KolInputText :_value="text" :_on="{ onChange: (e: unknown, v: string) => (text = v) }"></KolInputText>
-<KolButton _label="Text löschen" :_on="{ onClick: () => (text = '') }"></KolButton>
-```
-
-Hinweis: KoliBri-Inputs übergeben in der Regel das Ursprungsevent als ersten Parameter und den Wert des Feldes als Zweiten.
-
-### III React
-
-#### 1. Installieren der KoliBri-Bibliotheken
-
-<kol-tabs _headers="['npm', 'pnpm', 'yarn']" _tabs='[{"_label":"NPM"},{"_label":"PNPM"},{"_label":"YARN"}]'>
-	<div>npm i @public-ui/components @public-ui/themes @public-ui/react</div>
-	<div>pnpm i @public-ui/components @public-ui/themes @public-ui/react</div>
-	<div>yarn add @public-ui/components @public-ui/themes @public-ui/react</div>
-</kol-tabs>
-
-#### 2. Registrieren des KoliBri-Loaders
-
-Nachdem die Vorbereitungen abgeschlossen sind, muss nur noch der KoliBri-Loader registriert werden.
-Er sorgt dafür, dass die Web Components asynchron (lazy) nachgeladen werden, sobald sie in der Webseite verwendet werden.
-
-| Methode              | Erläuterung                                             |
-| -------------------- | ------------------------------------------------------- |
-| register             | Setzt ein Theme und registriert anschließend den Loader |
-| DEFAULT              | Registriert den Loader für z.B. das DEFAULT-Theme       |
-| defineCustomElements | Registriert den Loader für die Web Components           |
-
-#### 3. Integration
-
-```tsx
-import React from 'react';
-import ReactDOM from 'react-dom';
-
-import { AppComponent } from './components/app/component';
-
-import { register } from '@public-ui/core';
 import { defineCustomElements } from '@public-ui/components/loader';
-import { DEFAULT } from '@public-ui/themes';
+import { DEFAULT, ECL_EC, ECL_EU } from '@public-ui/themes';
 
-register(DEFAULT, defineCustomElements)
-	.then(() => {
-		const htmlDivElement: HTMLDivElement | null = document.querySelector<HTMLDivElement>('div#app');
-		if (htmlDivElement instanceof HTMLDivElement) {
-			const root = createRoot(htmlDivElement);
-			root.render(<AppComponent />);
-		}
-	})
-	.catch(console.warn);
+// Einzelnes Theme registrieren:
+register(DEFAULT, defineCustomElements).catch(console.warn);
+
+// Oder mehrere Themes registrieren und später umschalten:
+// register([DEFAULT, ECL_EC, ECL_EU], defineCustomElements);
 ```
 
-#### 4. Beispiel
+Die Themes der Seite können Sie über den Schalter in der Toolbar oben live ausprobieren und umschalten.
 
-```tsx
-import React from 'react';
-import { KolSpin } from '@public-ui/react-v19';
+### Eigenes Theme erstellen
 
-export const AppComponent = () => {
-	return (
-		<div>
-			<KolSpin _show />
-		</div>
-	);
-};
-```
+Wenn keines der mitgelieferten Themes zu Ihrem Corporate Design passt, können Sie ein **eigenes Theme** erstellen.
+Das Vorgehen orientiert sich am bestehenden Theme-Aufbau und wird vollständig im Code gepflegt.
 
-### IV Ohne Framework
+<KolLink _label="Theme selbst erstellen" _href="/docs/concepts/styling/designer" />
 
-<kol-tabs _headers="['npm', 'pnpm', 'yarn']" _tabs='[{"_label":"NPM"},{"_label":"PNPM"},{"_label":"YARN"}]'>
-	<div>npm i @public-ui/components @public-ui/themes</div>
-	<div>pnpm i @public-ui/components @public-ui/themes</div>
-	<div>yarn add @public-ui/components @public-ui/themes</div>
-</kol-tabs>
+## Nächste Schritte: Komponenten
 
-```diff
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Title</title>
-+   <script type="module" src="/node_modules/@public-ui/components/dist/kolibri/kolibri.esm.js"></script>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
-</html>
-```
-
-Um Codevervollständigung zu erhalten kann es notwendig sein `.vscode/settings.json` zu erstellen und Folgendes einzufügen:
-
-```json
-{
-	"html.customData": ["./node_modules/@public-ui/components/vscode-custom-data.json"]
-}
-```
-
-Hierbei ist die Web-Component Schreibweise (kebab-case) zu verwenden. (z.B.: `<kol-heading _label="">`)
-
-### V Statische Webseite
-
-Um KoliBri in eine statische Webseite einzubauen muss lediglich das folgende Script-Tag eingebunden werden.
-Sofern Schriftarten und/oder Icons verwendet werden, müssen diese, wie oben beschrieben, eingebunden werden.
-
-```html
-<script type="module">
-	import { register } from 'https://unpkg.com/@public-ui/components/dist/esm/index.js';
-	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components/loader/index.js';
-	import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default/dist/index.mjs';
-	register(DEFAULT, defineCustomElements).catch(console.warn);
-</script>
-```
-
-Hierbei ist die Web-Component Schreibweise (kebab-case) zu verwenden. (z.B.: `<kol-heading _label="">`)
-
-## Weitere Optionen
-
-### Entwickler Werkzeuge
-
-Mittels der folgenden Konfiguration in der HTML-Datei können die Entwickler-Werkzeuge von KoliBri aktiviert werden.
-
-```html
-…
-<html>
-	<head>
-		<meta name="kolibri" content="dev-mode=true" />
-	</head>
-	…
-</html>
-```
-
-### Experimenteller Modus
-
-Mittels der folgenden Konfiguration in der HTML-Datei kann der experimentelle Modus aktiviert werden.
-
-```html
-…
-<html>
-	<head>
-		<meta name="kolibri" content="experimental-mode=true" />
-	</head>
-	…
-</html>
-```
-
-### Farbkontrastanalyse
-
-Um Farbkontrastfehler innerhalb des DOMs zu erkennen, können Sie mittels der folgenden Konfiguration die Farbkontrastanalyse aktivieren.
-
-```html
-…
-<html>
-	<head>
-		<meta name="kolibri" content="color-constrast-analysis=true" />
-	</head>
-	…
-</html>
-```
+Sobald Ihr Projekt eingerichtet und ein Theme registriert ist, können Sie die KoliBri-Komponenten verwenden.
+Eine vollständige Übersicht aller verfügbaren Komponenten — mit Beispielen, Eigenschaften und Events — finden
+Sie in der <KolLink _label="Komponenten-Dokumentation" _href="/docs/components" />.

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -109,6 +109,67 @@ Das Vorgehen orientiert sich am bestehenden Theme-Aufbau und wird vollständig i
 
 <KolLink _label="Theme selbst erstellen" _href="/docs/concepts/styling/designer" />
 
+## Häufige Fragen
+
+<details>
+<summary><strong>Komponenten werden nicht angezeigt?</strong></summary>
+
+Stellen Sie sicher, dass `register()` **vor** dem Rendern aufgerufen wurde und das Promise aufgelöst ist.
+
+```tsx
+// ✅ Richtig
+register(DEFAULT, defineCustomElements).then(() => {
+	// Hier App rendern
+});
+
+// ❌ Falsch
+register(DEFAULT, defineCustomElements); // Promise nicht abgewartet
+// App wird sofort gerendert
+```
+
+</details>
+
+<details>
+<summary><strong>Welches Theme soll ich verwenden?</strong></summary>
+
+- **`DEFAULT`** – Neutrales Standard-Theme (empfohlen für den Start)
+- **`ECL_EC`** / **`ECL_EU`** – European Commission / Union Theme
+- **`KERN_V2`** – KERN Design-System Theme
+- Eine Übersicht aller Themes finden Sie oben im Abschnitt [Themes](#themes).
+- [Eigenes Theme erstellen](/docs/concepts/styling/designer)
+
+</details>
+
+<details>
+<summary><strong>TypeScript-Fehler bei Properties?</strong></summary>
+
+Prüfen Sie:
+
+1. `"moduleResolution": "Node"` in `tsconfig.json`
+2. Framework-Adapter installiert (z.B. `@public-ui/react-v19`)
+3. Komponenten aus dem Adapter importieren (nicht aus `@public-ui/components`)
+
+</details>
+
+<details>
+<summary><strong>Kann ich KoliBri ohne Build-Tool nutzen?</strong></summary>
+
+Ja! Laden Sie KoliBri per CDN:
+
+```html
+<script type="module">
+	import { register } from 'https://unpkg.com/@public-ui/components/dist/esm/index.js';
+	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components/loader/index.js';
+	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes/dist/index.mjs';
+
+	register(DEFAULT, defineCustomElements);
+</script>
+```
+
+Für Produktion sollten Sie fixe Versionen statt `@latest` verwenden.
+
+</details>
+
 ## Nächste Schritte: Komponenten
 
 Sobald Ihr Projekt eingerichtet und ein Theme registriert ist, können Sie die KoliBri-Komponenten verwenden.

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -7,8 +7,9 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 	werden kann.
 </KolAlert>
 
-**KoliBri** ist eine Bibliothek für barrierefreie Web Components. Die Komponenten sind framework-unabhängig und können
-in nahezu jedem webbasierten Projekt verwendet werden. Diese Seite gibt einen kompakten Überblick, wie Sie starten.
+**KoliBri** ist eine Open-Source-Bibliothek für barrierefreie Web Components, entwickelt von der Bundesregierung.
+Die Komponenten sind framework-unabhängig, nach BITV 2.0 und WCAG 2.2 konform und können in nahezu jedem
+webbasierten Projekt verwendet werden. Diese Seite gibt einen kompakten Überblick, wie Sie starten.
 
 ## Technologien
 
@@ -29,7 +30,11 @@ und Autovervollständigung ermöglichen:
 | `@public-ui/angular-v21` | Angular v21                        |
 | `@public-ui/hydrate`     | Server-Side-Rendering (SSR)        |
 
-Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden.
+### Web Components ohne Framework
+
+Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden —
+ohne Adapter, einfach per CDN-Import oder Skript-Tag.
+
 Weitere Details zur Verwendung der Web Components mit und ohne Framework finden Sie auf der Seite
 <KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
 
@@ -43,11 +48,6 @@ Es enthält vorgefertigte Starter-Templates für gängige Frameworks und Renderi
 ```
 npm init kolibri@latest my-kolibri-app
 ```
-
-<img
-	src="https://raw.githubusercontent.com/public-ui/.github/main/profile/create-kolibri.gif"
-	alt="Zeigt wie man mit create-kolibri eine neue App anlegen kann."
-/>
 
 ### Direkt aus einem Template (degit)
 
@@ -78,11 +78,11 @@ bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/theme
 | Theme       | Export       | Beschreibung                                        |
 | ----------- | ------------ | --------------------------------------------------- |
 | Default     | `DEFAULT`    | Das Standard-Theme von KoliBri                      |
-| BWSt        | `BWSt`       | Theme der Baustatistik (Baustatistik-Vorschrift); siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
-| Desy        | `DesyV11`    | Design-System Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
-| ECL (EC)    | `ECL_EC`     | European Commission Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
-| ECL (EU)    | `ECL_EU`     | European Union Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
-| KERN        | `KERN_V2`    | KERN Design-System Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
+| BWSt        | `BWSt`       | Wasserstraßen- und Schifffahrtsverwaltung des Bundes; <KolLink _label="Styleguide ↗" _href="https://wsv.bund.de" _target="_blank" /> |
+| Desy        | `DesyV11`    | Zoll Design-System (Generalzolldirektion); <KolLink _label="Styleguide ↗" _href="https://desy.zoll-portal.de" _target="_blank" /> |
+| ECL (EC)    | `ECL_EC`     | European Commission Design-System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
+| ECL (EU)    | `ECL_EU`     | European Union Design-System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
+| KERN        | `KERN_V2`    | KERN-UX Standard Design-System; <KolLink _label="Styleguide ↗" _href="https://www.kern-ux.de" _target="_blank" /> |
 
 ### Theme registrieren und umschalten
 
@@ -134,8 +134,8 @@ register(DEFAULT, defineCustomElements); // Promise nicht abgewartet
 <summary><strong>Welches Theme soll ich verwenden?</strong></summary>
 
 - **`DEFAULT`** – Neutrales Standard-Theme (empfohlen für den Start)
-- **`ECL_EC`** / **`ECL_EU`** – European Commission / Union Theme
-- **`KERN_V2`** – KERN Design-System Theme
+- **`ECL_EC`** / **`ECL_EU`** – European Commission / European Union Design-System
+- **`KERN_V2`** – KERN-UX Standard Design-System
 - Eine Übersicht aller Themes finden Sie oben im Abschnitt [Themes](#themes).
 - [Eigenes Theme erstellen](/docs/concepts/styling/designer)
 

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -30,7 +30,8 @@ und Autovervollständigung ermöglichen:
 | `@public-ui/hydrate`     | Server-Side-Rendering (SSR)        |
 
 Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden.
-Weitere Details finden Sie auf der Seite <KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
+Weitere Details zur Verwendung der Web Components mit und ohne Framework finden Sie auf der Seite
+<KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
 
 ## Projekt aus Vorlagen erstellen
 
@@ -77,11 +78,11 @@ bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/theme
 | Theme       | Export       | Beschreibung                                        |
 | ----------- | ------------ | --------------------------------------------------- |
 | Default     | `DEFAULT`    | Das Standard-Theme von KoliBri                      |
-| BWSt        | `BWSt`       | Theme der Baustatistik (Baustatistik-Vorschrift)    |
-| Desy        | `DesyV11`    | Design-System Theme                                 |
-| ECL (EC)    | `ECL_EC`     | European Commission Theme                           |
-| ECL (EU)    | `ECL_EU`     | European Union Theme                                |
-| KERN        | `KERN_V2`    | KERN Design-System Theme                            |
+| BWSt        | `BWSt`       | Theme der Baustatistik (Baustatistik-Vorschrift); siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
+| Desy        | `DesyV11`    | Design-System Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
+| ECL (EC)    | `ECL_EC`     | European Commission Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
+| ECL (EU)    | `ECL_EU`     | European Union Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
+| KERN        | `KERN_V2`    | KERN Design-System Theme; siehe <KolLink _label="Design-System" _href="/docs/concepts/styling/designer" /> für Styleguide |
 
 ### Theme registrieren und umschalten
 


### PR DESCRIPTION
## Summary

Die Getting-Started-Seite wird von einer langen, framework-für-framework Anleitung zu einem kompakten 1-Pager umgebaut, der die wesentlichen Einstiegsfragen schnell beantwortet.

### Neue Struktur

1. **Technologien** — Welche Frameworks/Adapter KoliBri unterstützt (React, Vue, Angular, Solid, Preact, SSR, Web Components)
2. **Projekt aus Vorlagen erstellen** — `create-kolibri` CLI und direkter Template-Klon via `degit` aus dem [public-ui/templates](https://github.com/public-ui/templates) Repository
3. **Themes** — Welche Themes mit `@public-ui/themes` geliefert werden und wie man sie registriert/umschaltet:
   - `DEFAULT`, `BWSt`, `DesyV11`, `ECL_EC`, `ECL_EU`, `KERN_V2`
4. **Eigenes Theme erstellen** — Hinweis + Link zur [Theme-Anleitung](/docs/concepts/styling/designer)
5. **Komponenten** — Überleitung zur [Komponenten-Dokumentation](/docs/components)

### Was entfernt wurde

Die detaillierten manuellen Integrations-Schritte (Schriftarten, TypeScript, Vite+React, Vite+Vue, React, Ohne Framework, Statische Webseite) werden von der Seite genommen. Nutzer, die KoliBri manuell in ein bestehendes Projekt einbinden möchten, finden diese Inhalte weiterhin auf der **Frameworks**-Seite.

### Bezug zu Issue #769

Das Ticket beschrieb u.a. die Frustration, dass die Getting-Started-Seite zu lang und unübersichtlich war. Der 1-Pager gibt jetzt einen klaren roten Faden: Techs → Templates → Themes → eigene Themes → Komponenten.

## Test Plan

- [x] `pnpm run lint` bestanden
- [x] `pnpm run build` bestanden
- [ ] Seite visuell prüfen

Closes #769