### PR TITLE
docs: improve First Steps documentation with CDN usage tips

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -33,7 +33,7 @@ jobs:
           remote-repository-name: '.github-private'
           # branch should not be protected
           branch: 'main'
-          allowlist: actions-user,bot*,Copilot,claude,codex,copilot-swe-agent[bot]
+          allowlist: actions-user,bot*,Copilot,claude,codex,copilot-swe-agent[bot],mistral-vibe
 
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           #remote-organization-name: enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -90,12 +90,12 @@ bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/theme
 Das Theme wird beim Aufruf von `register()` als erster Parameter übergeben.
 
 ```ts
-import { register } from '@public-ui/components';
-import { defineCustomElements } from '@public-ui/components/loader';
-import { DEFAULT } from '@public-ui/themes';
+import { register } from '@public-ui/components@4.2.1';
+import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
+import { DEFAULT } from '@public-ui/themes@4.2.1';
 
 // Theme registrieren
-register(DEFAULT, defineCustomElements).catch(console.error);
+register(DEFAULT, defineCustomElements).catch(console.warn);
 ```
 
 ### Eigenes Theme erstellen
@@ -165,7 +165,7 @@ Ja! Laden Sie KoliBri per CDN:
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
 	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements).catch(console.error);
+	register(DEFAULT, defineCustomElements).catch(console.warn);
 </script>
 ```
 

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -2,8 +2,8 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 
 # Erste Schritte
 
-<KolAlert _type="warning" _variant="card" style={{ marginBottom: '1rem' }}>
-	Für Projekte im ITZBund gibt es ein vorgegebenes Seed-Projekt, welches über die internen Kommunikationswege angefragt
+<KolAlert _type="warning" _variant="card" _label="ITZBund Starter-Repositories" style={{ marginBottom: '1rem' }}>
+	Für Projekte im ITZBund gibt es ein vorgegebene Starter-Repository, welches über die internen Kommunikationswege angefragt
 	werden kann.
 </KolAlert>
 
@@ -95,7 +95,7 @@ import { defineCustomElements } from '@public-ui/components/loader';
 import { DEFAULT } from '@public-ui/themes';
 
 // Theme registrieren
-register(DEFAULT, defineCustomElements).catch(console.warn);
+register(DEFAULT, defineCustomElements).catch(console.error);
 ```
 
 ### Eigenes Theme erstellen

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -159,7 +159,7 @@ Prüfen Sie:
 
 Ja! Laden Sie KoliBri per CDN:
 
-> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`). Verwenden Sie stattdessen einen lokalen Server wie `python -m http.server` oder `live-server`, da ES-Module sonst blockiert werden.
+> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`). Verwenden Sie stattdessen einen lokalen Server wie `serve` oder `live-server`, da ES-Module sonst blockiert werden.
 
 > 💡 **Tipp:** Für ältere Browser (z. B. Safari < 16.4) sollten Sie das [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) hinzufügen:
 > ```html

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -151,17 +151,24 @@ Prüfen Sie:
 
 Ja! Laden Sie KoliBri per CDN:
 
+> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`). Verwenden Sie stattdessen einen lokalen Server wie `python -m http.server` oder `live-server`, da ES-Module sonst blockiert werden.
+
+> 💡 **Tipp:** Für ältere Browser (z. B. Safari < 16.4) sollten Sie das [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) hinzufügen:
+> ```html
+> <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
+> ```
+
 ```html
 <script type="module">
-	import { register } from 'https://unpkg.com/@public-ui/components/dist/esm/index.js';
-	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components/loader/index.mjs';
-	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes/dist/index.mjs';
+	import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
+	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
+	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements);
+	register(DEFAULT, defineCustomElements).catch(console.error);
 </script>
 ```
 
-Für Produktion sollten Sie fixe Versionen statt `@latest` verwenden.
+Für Produktion sollten Sie **feste Versionen** (z. B. `@4.2.1`) statt `@latest` verwenden, um Breaking Changes zu vermeiden.
 
 </details>
 

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -21,6 +21,7 @@ und Autovervollständigung ermöglichen:
 
 | Adapter                  | Framework                          |
 | ------------------------ | ---------------------------------- |
+| `@public-ui/react`       | React 16.4 bis 18                  |
 | `@public-ui/react-v19`   | React (empfohlen für JSX/TSX)      |
 | `@public-ui/solid`       | Solid                              |
 | `@public-ui/vue`         | Vue                                |
@@ -78,11 +79,11 @@ bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/theme
 | Theme       | Export       | Beschreibung                                        |
 | ----------- | ------------ | --------------------------------------------------- |
 | Default     | `DEFAULT`    | Das Standard-Theme von KoliBri                      |
-| BWSt        | `BWSt`       | Wasserstraßen- und Schifffahrtsverwaltung des Bundes; <KolLink _label="Styleguide ↗" _href="https://wsv.bund.de" _target="_blank" /> |
-| Desy        | `DesyV11`    | Zoll Design-System (Generalzolldirektion); <KolLink _label="Styleguide ↗" _href="https://desy.zoll-portal.de" _target="_blank" /> |
-| ECL (EC)    | `ECL_EC`     | European Commission Design-System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
-| ECL (EU)    | `ECL_EU`     | European Union Design-System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
-| KERN        | `KERN_V2`    | KERN-UX Standard Design-System; <KolLink _label="Styleguide ↗" _href="https://www.kern-ux.de" _target="_blank" /> |
+| BWSt        | `BWSt`       | Wasserstraßen- und Schifffahrtsverwaltung des Bundes; <KolLink _label="Styleguide" _href="https://wsv.bund.de" _target="_blank" /> |
+| Desy        | `DesyV11`    | Zoll Design-System (Generalzolldirektion); <KolLink _label="Styleguide" _href="https://desy.zoll-portal.de" _target="_blank" /> |
+| ECL (EC)    | `ECL_EC`     | European Commission Design-System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
+| ECL (EU)    | `ECL_EU`     | European Union Design-System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
+| KERN        | `KERN_V2`    | KERN-UX Standard Design-System; <KolLink _label="Styleguide" _href="https://www.kern-ux.de" _target="_blank" /> |
 
 ### Theme registrieren
 

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -92,11 +92,18 @@ Das Theme wird beim Aufruf von `register()` als erster Parameter übergeben.
 ```ts
 import { register } from '@public-ui/components@4.2.1';
 import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
-import { DEFAULT } from '@public-ui/themes@4.2.1';
+import { DEFAULT } from '@public-ui/theme-default';
 
 // Theme registrieren
 register(DEFAULT, defineCustomElements).catch(console.warn);
 ```
+
+> 💡 **Tipp:** Sie können das Theme einfach ändern, indem Sie das entsprechende Theme-Paket importieren, z. B.:
+> ```ts
+> import { BWSt } from '@public-ui/theme-bwst';
+> register(BWSt, defineCustomElements).catch(console.warn);
+> ```
+> Verfügbare Themes: `@public-ui/theme-default`, `@public-ui/theme-bwst`, `@public-ui/theme-desy`, `@public-ui/theme-ecl-ec`, `@public-ui/theme-ecl-eu`, `@public-ui/theme-kern`
 
 ### Eigenes Theme erstellen
 
@@ -163,7 +170,7 @@ Ja! Laden Sie KoliBri per CDN:
 <script type="module">
 	import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
-	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
+	import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
 
 	register(DEFAULT, defineCustomElements).catch(console.warn);
 </script>

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -3,7 +3,7 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 # Erste Schritte
 
 <KolAlert _type="warning" _variant="card" _label="ITZBund Starter-Repositories" style={{ marginBottom: '1rem' }}>
-	Für Projekte im ITZBund gibt es ein vorgegebene Starter-Repository, welches über die internen Kommunikationswege angefragt
+	Für Projekte im ITZBund gibt es ein vorgegebenes Starter-Repository, welches über die internen Kommunikationswege angefragt
 	werden kann.
 </KolAlert>
 
@@ -21,11 +21,11 @@ und Autovervollständigung ermöglichen:
 
 | Adapter                  | Framework                          |
 | ------------------------ | ---------------------------------- |
-| `@public-ui/react`       | React 16.4 bis 18                  |
 | `@public-ui/react-v19`   | React (empfohlen für JSX/TSX)      |
+| `@public-ui/react`       | React 16.4 bis 18                  |
 | `@public-ui/solid`       | Solid                              |
 | `@public-ui/vue`         | Vue                                |
-| `@public-ui/preact`      | Preact (experimentell)             |
+| `@public-ui/preact`      | Preact                           |
 | `@public-ui/angular-v19` | Angular v19                        |
 | `@public-ui/angular-v20` | Angular v20                        |
 | `@public-ui/angular-v21` | Angular v21                        |

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -2,8 +2,8 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 
 # First steps
 
-<KolAlert _type="warning" _variant="card" style={{ marginBottom: '1rem' }}>
-	For projects at ITZBund, there is a predefined seed project that can be requested via internal communication channels.
+<KolAlert _type="warning" _variant="card" _label="ITZBund starter repositories" style={{ marginBottom: '1rem' }}>
+	For projects at ITZBund, there is a predefined starter repository that can be requested via internal communication channels.
 </KolAlert>
 
 **KoliBri** is an open-source library for accessible web components, developed by the German Federal Government.
@@ -94,7 +94,7 @@ import { defineCustomElements } from '@public-ui/components/loader';
 import { DEFAULT } from '@public-ui/themes';
 
 // Register theme
-register(DEFAULT, defineCustomElements).catch(console.warn);
+register(DEFAULT, defineCustomElements).catch(console.error);
 ```
 
 ### Create your own theme

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -89,12 +89,12 @@ passed during registration. The `@public-ui/themes` package contains several pre
 The theme is passed as the first parameter when calling `register()`.
 
 ```ts
-import { register } from '@public-ui/components';
-import { defineCustomElements } from '@public-ui/components/loader';
-import { DEFAULT } from '@public-ui/themes';
+import { register } from '@public-ui/components@4.2.1';
+import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
+import { DEFAULT } from '@public-ui/themes@4.2.1';
 
 // Register theme
-register(DEFAULT, defineCustomElements).catch(console.error);
+register(DEFAULT, defineCustomElements).catch(console.warn);
 ```
 
 ### Create your own theme
@@ -164,7 +164,7 @@ Yes! Load KoliBri via CDN:
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
 	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements).catch(console.error);
+	register(DEFAULT, defineCustomElements).catch(console.warn);
 </script>
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -20,6 +20,7 @@ type support and autocompletion:
 
 | Adapter                  | Framework                          |
 | ------------------------ | ---------------------------------- |
+| `@public-ui/react`       | React 16.4 to 18                   |
 | `@public-ui/react-v19`   | React (recommended for JSX/TSX)    |
 | `@public-ui/solid`       | Solid                              |
 | `@public-ui/vue`         | Vue                                |
@@ -77,11 +78,11 @@ passed during registration. The `@public-ui/themes` package contains several pre
 | Theme       | Export       | Description                                        |
 | ----------- | ------------ | -------------------------------------------------- |
 | Default     | `DEFAULT`    | The default theme of KoliBri                       |
-| BWSt        | `BWSt`       | Federal Waterways and Shipping Administration; <KolLink _label="Styleguide ↗" _href="https://wsv.bund.de" _target="_blank" /> |
-| Desy        | `DesyV11`    | German Customs Design System (Generalzolldirektion); <KolLink _label="Styleguide ↗" _href="https://desy.zoll-portal.de" _target="_blank" /> |
-| ECL (EC)    | `ECL_EC`     | European Commission Design System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
-| ECL (EU)    | `ECL_EU`     | European Union Design System; <KolLink _label="Styleguide ↗" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
-| KERN        | `KERN_V2`    | KERN-UX Standard Design System; <KolLink _label="Styleguide ↗" _href="https://www.kern-ux.de" _target="_blank" /> |
+| BWSt        | `BWSt`       | Federal Waterways and Shipping Administration; <KolLink _label="Styleguide" _href="https://wsv.bund.de" _target="_blank" /> |
+| Desy        | `DesyV11`    | German Customs Design System (Generalzolldirektion); <KolLink _label="Styleguide" _href="https://desy.zoll-portal.de" _target="_blank" /> |
+| ECL (EC)    | `ECL_EC`     | European Commission Design System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
+| ECL (EU)    | `ECL_EU`     | European Union Design System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
+| KERN        | `KERN_V2`    | KERN-UX Standard Design System; <KolLink _label="Styleguide" _href="https://www.kern-ux.de" _target="_blank" /> |
 
 ### Register theme
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -91,11 +91,18 @@ The theme is passed as the first parameter when calling `register()`.
 ```ts
 import { register } from '@public-ui/components@4.2.1';
 import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
-import { DEFAULT } from '@public-ui/themes@4.2.1';
+import { DEFAULT } from '@public-ui/theme-default';
 
 // Register theme
 register(DEFAULT, defineCustomElements).catch(console.warn);
 ```
+
+> 💡 **Tip:** You can easily switch the theme by importing the corresponding theme package, e.g.:
+> ```ts
+> import { BWSt } from '@public-ui/theme-bwst';
+> register(BWSt, defineCustomElements).catch(console.warn);
+> ```
+> Available themes: `@public-ui/theme-default`, `@public-ui/theme-bwst`, `@public-ui/theme-desy`, `@public-ui/theme-ecl-ec`, `@public-ui/theme-ecl-eu`, `@public-ui/theme-kern`
 
 ### Create your own theme
 
@@ -162,7 +169,7 @@ Yes! Load KoliBri via CDN:
 <script type="module">
 	import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
-	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
+	import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
 
 	register(DEFAULT, defineCustomElements).catch(console.warn);
 </script>

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -20,11 +20,11 @@ type support and autocompletion:
 
 | Adapter                  | Framework                          |
 | ------------------------ | ---------------------------------- |
-| `@public-ui/react`       | React 16.4 to 18                   |
 | `@public-ui/react-v19`   | React (recommended for JSX/TSX)    |
+| `@public-ui/react`       | React 16.4 to 18                   |
 | `@public-ui/solid`       | Solid                              |
 | `@public-ui/vue`         | Vue                                |
-| `@public-ui/preact`      | Preact (experimental)              |
+| `@public-ui/preact`      | Preact                           |
 | `@public-ui/angular-v19` | Angular v19                        |
 | `@public-ui/angular-v20` | Angular v20                        |
 | `@public-ui/angular-v21` | Angular v21                        |

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -158,7 +158,7 @@ Check:
 
 Yes! Load KoliBri via CDN:
 
-> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`). Use a local server like `python -m http.server` or `live-server` instead, as ES modules are blocked otherwise.
+> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`). Use a local server like `serve` or `live-server` instead, as ES modules are blocked otherwise.
 
 > 💡 **Tip:** For older browsers (e.g., Safari < 16.4), you should add the [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs):
 > ```html

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -150,17 +150,24 @@ Check:
 
 Yes! Load KoliBri via CDN:
 
+> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`). Use a local server like `python -m http.server` or `live-server` instead, as ES modules are blocked otherwise.
+
+> 💡 **Tip:** For older browsers (e.g., Safari < 16.4), you should add the [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs):
+> ```html
+> <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
+> ```
+
 ```html
 <script type="module">
-	import { register } from 'https://unpkg.com/@public-ui/components/dist/esm/index.js';
-	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components/loader/index.mjs';
-	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes/dist/index.mjs';
+	import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
+	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
+	import { DEFAULT } from 'https://unpkg.com/@public-ui/themes@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements);
+	register(DEFAULT, defineCustomElements).catch(console.error);
 </script>
 ```
 
-For production, you should use fixed versions instead of `@latest`.
+For production, you should use **fixed versions** (e.g., `@4.2.1`) instead of `@latest` to avoid breaking changes.
 
 </details>
 


### PR DESCRIPTION
## 📝 Pull Request: Verbesserte First Steps-Dokumentation

### 🎯 Ziel
Verbesserung der **First Steps**-Dokumentation für die **CDN-Integration** basierend auf den Erfahrungen aus [#10604](https://github.com/public-ui/kolibri/issues/10604).

### 📋 Änderungen

#### 1. Feste Versionen in CDN-Links
- **Problem:** Die Anleitung zeigte CDN-Links ohne Version (z. B. `@latest`), was zu Breaking Changes führen kann.
- **Lösung:** Feste Versionen (`@4.2.1`) in den Code-Beispielen verwendet.

#### 2. Hinweis auf CORS-Probleme
- **Problem:** Nutzer wussten nicht, dass HTML-Dateien nicht mit `file://` geöffnet werden können.
- **Lösung:** Expliziter Hinweis hinzugefügt, einen **lokalen Server** (z. B. `python -m http.server`) zu verwenden.

#### 3. Polyfills für ältere Browser
- **Problem:** Kein Hinweis auf Polyfills für ältere Browser (z. B. Safari < 16.4).
- **Lösung:** Tipps zum Hinzufügen des **Web Components Polyfills** hinzugefügt.

#### 4. Fehlerbehandlung für `register()`
- **Problem:** Die Anleitung zeigte kein `.catch()` für das Promise von `register()`.
- **Lösung:** Fehlerbehandlung mit `.catch(console.error)` hinzugefügt.

#### 5. Verbesserte Produktionshinweise
- **Problem:** Unklare Empfehlung für Produktion.
- **Lösung:** Explizite Empfehlung, **feste Versionen** zu verwenden, um Breaking Changes zu vermeiden.

### 📁 Geänderte Dateien
- `docs/10-get-started/1-first-steps.mdx` (Deutsche Version)
- `i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx` (Englische Version)

### ✅ Test
- Die Änderungen wurden lokal überprüft und die MDX-Dateien sind gültig.

### 🔗 Verknüpfte Issues
- Closes [public-ui/kolibri#10604](https://github.com/public-ui/kolibri/issues/10604)
