### PR TITLE
docs: Klarstellung zur lokalen Server-Nutzung in Getting Started

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -44,16 +44,9 @@ Weitere Details zur Verwendung der Web Components mit und ohne Framework finden 
 Der schnellste Weg zu einem lauffähigen KoliBri-Projekt ist das <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
 Es enthält vorgefertigte Starter-Templates für gängige Frameworks und Rendering-Varianten.
 
-### Mit dem Kommandozeilenassistenten
-
-```
-npm init kolibri@latest my-kolibri-app
-```
-
 ### Direkt aus einem Template (degit)
 
-Alternativ kann ein Template direkt aus dem Repository geklont werden. Ersetzen Sie `<framework>` durch den
-gewünschten Template-Namen:
+Klonen Sie ein Template direkt aus dem Repository. Ersetzen Sie `<framework>` durch den gewünschten Template-Namen:
 
 | Framework | Template                           |
 | --------- | ---------------------------------- |

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -159,7 +159,7 @@ Prüfen Sie:
 
 Ja! Laden Sie KoliBri per CDN:
 
-> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`). Verwenden Sie stattdessen einen lokalen Server wie `serve` oder `live-server`, da ES-Module sonst blockiert werden.
+> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`), da ES-Module sonst blockiert werden. Führen Sie stattdessen `npx serve` in Ihrem Terminal aus und öffnen Sie die angezeigte URL (z. B. http://localhost:3000) in Ihrem Browser.
 
 > 💡 **Tipp:** Für ältere Browser (z. B. Safari < 16.4) sollten Sie das [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) hinzufügen:
 > ```html

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -158,7 +158,7 @@ Check:
 
 Yes! Load KoliBri via CDN:
 
-> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`). Use a local server like `serve` or `live-server` instead, as ES modules are blocked otherwise.
+> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`), as ES modules are blocked. Instead, run `npx serve` in your terminal and open the displayed URL (e.g., http://localhost:3000) in your browser.
 
 > 💡 **Tip:** For older browsers (e.g., Safari < 16.4), you should add the [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs):
 > ```html

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -43,16 +43,9 @@ Further details on using web components with and without a framework can be foun
 The fastest way to a working KoliBri project is the <KolLink _label="template repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
 It contains pre-built starter templates for common frameworks and rendering variants.
 
-### Using the command line wizard
-
-```
-npm init kolibri@latest my-kolibri-app
-```
-
 ### Directly from a template (degit)
 
-Alternatively, a template can be cloned directly from the repository. Replace `<framework>` with the
-desired template name:
+Clone a template directly from the repository. Replace `<framework>` with the desired template name:
 
 | Framework | Template                           |
 | --------- | ---------------------------------- |


### PR DESCRIPTION
## Summary
- Ersetzt vage Hinweise ('Verwenden Sie einen lokalen Server wie serve oder live-server') durch eine konkrete Handlungsanweisung: **'Führen Sie stattdessen npx serve in Ihrem Terminal aus und öffnen Sie die angezeigte URL (z. B. http://localhost:3000) in Ihrem Browser.'**

## Changes
- Anpassung der deutschen Version (docs/10-get-started/1-first-steps.mdx)
- Anpassung der englischen Version (i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx)

## Why?
Der bisherige Hinweis war zu unkonkret und führte bei Anfängern zu Verwirrung, da nicht klar war, wie man einen lokalen Server startet. Mit npx serve haben Nutzer einen einfachen, plattformunabhängigen Befehl, der sofort funktioniert (keine Installation nötig).

## Related Issue
Closes #782