### PR TITLE
docs: Entfernt nicht-funktionierenden CLI-Befehl, empfiehlt degit

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -44,16 +44,9 @@ Weitere Details zur Verwendung der Web Components mit und ohne Framework finden 
 Der schnellste Weg zu einem lauffähigen KoliBri-Projekt ist das <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
 Es enthält vorgefertigte Starter-Templates für gängige Frameworks und Rendering-Varianten.
 
-### Mit dem Kommandozeilenassistenten
-
-```
-npm init kolibri@latest my-kolibri-app
-```
-
 ### Direkt aus einem Template (degit)
 
-Alternativ kann ein Template direkt aus dem Repository geklont werden. Ersetzen Sie `<framework>` durch den
-gewünschten Template-Namen:
+Klonen Sie ein Template direkt aus dem Repository. Ersetzen Sie `<framework>` durch den gewünschten Template-Namen:
 
 | Framework | Template                           |
 | --------- | ---------------------------------- |

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -43,16 +43,9 @@ Further details on using web components with and without a framework can be foun
 The fastest way to a working KoliBri project is the <KolLink _label="template repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
 It contains pre-built starter templates for common frameworks and rendering variants.
 
-### Using the command line wizard
-
-```
-npm init kolibri@latest my-kolibri-app
-```
-
 ### Directly from a template (degit)
 
-Alternatively, a template can be cloned directly from the repository. Replace `<framework>` with the
-desired template name:
+Clone a template directly from the repository. Replace `<framework>` with the desired template name:
 
 | Framework | Template                           |
 | --------- | ---------------------------------- |


### PR DESCRIPTION
## Summary
- Entfernt den nicht-funktionierenden CLI-Befehl (`npm init kolibri@latest`) aus der Dokumentation.
- Macht die `npx degit`-Methode zur primären Empfehlung für die Template-Erstellung.

## Changes
- Entfernt den Abschnitt **"Mit dem Kommandozeilenassistenten"** (deutsche Version).
- Entfernt den Abschnitt **"Using the command line wizard"** (englische Version).
- Passt die Formulierung an, um `npx degit` als direkte Methode zu empfehlen.

## Why?
Der Befehl `npm init kolibri@latest` funktioniert aktuell nicht wie in der Dokumentation beschrieben. Stattdessen zeigt der Assistent eine abweichende Anleitung an (`npx degit`). Um Verwirrung für Anfänger zu vermeiden, wird die Dokumentation auf die **funktionierende Methode** (`npx degit`) umgestellt.

## Related Issue
Closes #784