### PR TITLE
feat(docs): use npx -y serve and await register() in CDN examples

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -11,6 +11,11 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 Die Komponenten sind framework-unabhängig, nach BITV 2.0 und WCAG 2.2 konform und können in nahezu jedem
 webbasierten Projekt verwendet werden. Diese Seite gibt einen kompakten Überblick, wie Sie starten.
 
+> **⚠️ Voraussetzungen**
+> - Ein **moderner Browser** (Chrome, Firefox, Edge, Safari ≥ 16.4).
+> - Für lokale Entwicklung: **[Node.js](https://nodejs.org/)** (für `npx serve`).
+> - Optional: [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) für ältere Browser (Safari < 16.4).
+
 ## Technologien
 
 KoliBri wird in der öffentlichen <KolLink _label="NPM-Registry" _href="https://www.npmjs.com/search?q=%40public-ui" _target="_blank" /> versioniert bereitgestellt.
@@ -34,8 +39,49 @@ und Autovervollständigung ermöglichen:
 ### Web Components ohne Framework
 
 Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden —
-ohne Adapter, einfach per CDN-Import oder Skript-Tag.
+ohne Adapter, einfach per CDN-Import. **Dies ist der schnellste Weg, um KoliBri auszuprobieren!**
 
+
+
+#### Schnellstart mit CDN
+
+Erstellen Sie eine `index.html` mit folgendem Inhalt:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>KoliBri Minimalbeispiel</title>
+    <!-- Polyfill für ältere Browser (optional) -->
+    <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
+</head>
+<body>
+    <h1>KoliBri Test</h1>
+    <kol-button _label="Klick mich" onclick="handleClick()"></kol-button>
+
+    <script type="module">
+        import { register } from 'https://unpkg.com/@public-ui/components@latest/dist/esm/index.mjs';
+        import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@latest/loader/index.mjs';
+        import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@latest/dist/index.mjs';
+
+        await register(DEFAULT, defineCustomElements);
+
+        function handleClick() {
+            alert("Button geklickt!");
+        }
+        window.handleClick = handleClick;
+    </script>
+</body>
+</html>
+```
+
+> **🔥 Wichtig:**
+> - Verwenden Sie **`await register()`**, um sicherzustellen, dass die Komponenten vor dem Rendern registriert sind.
+> - Öffnen Sie die HTML-Datei **nicht** direkt im Browser (`file://`). Starten Sie stattdessen einen lokalen Server:
+>   ```bash
+>   npx -y serve
+>   ```
+>   und öffnen Sie [http://localhost:3000](http://localhost:3000).
 Weitere Details zur Verwendung der Web Components mit und ohne Framework finden Sie auf der Seite
 <KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
 
@@ -110,7 +156,7 @@ Das Vorgehen orientiert sich am bestehenden Theme-Aufbau und wird vollständig i
 <details>
 <summary><strong>Komponenten werden nicht angezeigt?</strong></summary>
 
-Stellen Sie sicher, dass `register()` **vor** dem Rendern aufgerufen wurde und das Promise aufgelöst ist.
+Stellen Sie sicher, dass `register()` **vor** dem Rendern der Komponenten abgeschlossen ist. Verwenden Sie `await` oder `.then()`:
 
 ```tsx
 // ✅ Richtig
@@ -169,7 +215,7 @@ Ja! Laden Sie KoliBri per CDN:
 </script>
 ```
 
-Für Produktion sollten Sie **feste Versionen** (z. B. `@4.2.1`) statt `@latest` verwenden, um Breaking Changes zu vermeiden.
+> **💡 Tipp für Produktion:** Ersetzen Sie `@latest` durch eine feste Version (z. B. `@4.2.1`), um Breaking Changes zu vermeiden.
 
 </details>
 

--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -88,7 +88,7 @@ import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
 import { DEFAULT } from '@public-ui/theme-default';
 
 // Theme registrieren
-register(DEFAULT, defineCustomElements).catch(console.warn);
+await register(DEFAULT, defineCustomElements);
 ```
 
 > 💡 **Tipp:** Sie können das Theme einfach ändern, indem Sie das entsprechende Theme-Paket importieren, z. B.:
@@ -152,7 +152,7 @@ Prüfen Sie:
 
 Ja! Laden Sie KoliBri per CDN:
 
-> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`), da ES-Module sonst blockiert werden. Führen Sie stattdessen `npx serve` in Ihrem Terminal aus und öffnen Sie die angezeigte URL (z. B. http://localhost:3000) in Ihrem Browser.
+> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`), da ES-Module sonst blockiert werden. Führen Sie stattdessen `npx -y serve` in Ihrem Terminal aus und öffnen Sie die angezeigte URL (z. B. http://localhost:3000) in Ihrem Browser.
 
 > 💡 **Tipp:** Für ältere Browser (z. B. Safari < 16.4) sollten Sie das [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) hinzufügen:
 > ```html
@@ -165,7 +165,7 @@ Ja! Laden Sie KoliBri per CDN:
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
 	import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements).catch(console.warn);
+	await register(DEFAULT, defineCustomElements);
 </script>
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -87,7 +87,7 @@ import { defineCustomElements } from '@public-ui/components@4.2.1/loader';
 import { DEFAULT } from '@public-ui/theme-default';
 
 // Register theme
-register(DEFAULT, defineCustomElements).catch(console.warn);
+await register(DEFAULT, defineCustomElements);
 ```
 
 > 💡 **Tip:** You can easily switch the theme by importing the corresponding theme package, e.g.:
@@ -151,7 +151,7 @@ Check:
 
 Yes! Load KoliBri via CDN:
 
-> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`), as ES modules are blocked. Instead, run `npx serve` in your terminal and open the displayed URL (e.g., http://localhost:3000) in your browser.
+> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`), as ES modules are blocked. Instead, run `npx -y serve` in your terminal and open the displayed URL (e.g., http://localhost:3000) in your browser.
 
 > 💡 **Tip:** For older browsers (e.g., Safari < 16.4), you should add the [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs):
 > ```html
@@ -164,7 +164,7 @@ Yes! Load KoliBri via CDN:
 	import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
 	import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
 
-	register(DEFAULT, defineCustomElements).catch(console.warn);
+	await register(DEFAULT, defineCustomElements);
 </script>
 ```
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -10,6 +10,11 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 The components are framework-independent, compliant with BITV 2.0 and WCAG 2.2, and can be used in almost any
 web-based project. This page provides a compact overview of how to get started.
 
+> **⚠️ Prerequisites**
+> - A **modern browser** (Chrome, Firefox, Edge, Safari ≥ 16.4).
+> - For local development: **[Node.js](https://nodejs.org/)** (required for `npx serve`).
+> - Optional: [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) for older browsers (Safari < 16.4).
+
 ## Technologies
 
 KoliBri is versioned and provided in the public <KolLink _label="NPM registry" _href="https://www.npmjs.com/search?q=%40public-ui" _target="_blank" />.
@@ -33,8 +38,49 @@ type support and autocompletion:
 ### Web Components without a framework
 
 For static websites or projects without a framework, the web components can also be used **directly** —
-without an adapter, simply via CDN import or script tag.
+without an adapter, simply via CDN import. **This is the fastest way to try out KoliBri!**
 
+
+
+#### Quick Start with CDN
+
+Create an `index.html` file with the following content:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <title>KoliBri Minimal Example</title>
+    <!-- Polyfill for older browsers (optional) -->
+    <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
+</head>
+<body>
+    <h1>KoliBri Test</h1>
+    <kol-button _label="Click me" onclick="handleClick()"></kol-button>
+
+    <script type="module">
+        import { register } from 'https://unpkg.com/@public-ui/components@latest/dist/esm/index.mjs';
+        import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@latest/loader/index.mjs';
+        import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@latest/dist/index.mjs';
+
+        await register(DEFAULT, defineCustomElements);
+
+        function handleClick() {
+            alert("Button clicked!");
+        }
+        window.handleClick = handleClick;
+    </script>
+</body>
+</html>
+```
+
+> **🔥 Important:**
+> - Use **`await register()`** to ensure components are registered before rendering.
+> - Do **not** open the HTML file directly in the browser (`file://`). Instead, start a local server:
+>   ```bash
+>   npx -y serve
+>   ```
+>   and open [http://localhost:3000](http://localhost:3000).
 Further details on using web components with and without a framework can be found on the
 <KolLink _label="Frameworks" _href="/en/docs/get-started/frameworks" /> page.
 
@@ -109,7 +155,7 @@ The approach follows the existing theme structure and is maintained entirely in 
 <details>
 <summary><strong>Components are not displayed?</strong></summary>
 
-Make sure that `register()` is called **before** rendering and that the promise is resolved.
+Make sure that `register()` is completed **before** rendering components. Use `await` or `.then()`:
 
 ```tsx
 // ✅ Correct
@@ -168,7 +214,7 @@ Yes! Load KoliBri via CDN:
 </script>
 ```
 
-For production, you should use **fixed versions** (e.g., `@4.2.1`) instead of `@latest` to avoid breaking changes.
+> **💡 Tip for production:** Replace `@latest` with a fixed version (e.g., `@4.2.1`) to avoid breaking changes.
 
 </details>
 


### PR DESCRIPTION
### Summary
- Replace `npx serve` with `npx -y serve` for automatic confirmation in CDN examples.
- Replace `register().catch()` with `await register()` for better readability.

### Changes
- **German docs:** `docs/10-get-started/1-first-steps.mdx`
- **English docs:** `i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx`

Closes #787
