### PR TITLE
feat(docs): add MCP Server section to Getting Started guide

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -39,6 +39,23 @@ ohne Adapter, einfach per CDN-Import oder Skript-Tag.
 Weitere Details zur Verwendung der Web Components mit und ohne Framework finden Sie auf der Seite
 <KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
 
+
+### KoliBri mit KI-Assistenten nutzen (MCP)
+
+KoliBri bietet einen **Model Context Protocol (MCP) Server**, mit dem Sie die Dokumentation und Komponenten direkt in Ihrer KI-Umgebung (z. B. Cursor, Claude Code, oder VS Code mit MCP-Erweiterungen) nutzen können.
+
+🔗 **[MCP-Server ausprobieren](https://public-ui-kolibri-mcp.vercel.app/)**
+
+**Vorteile:**
+- **Direkter Zugriff** auf die KoliBri-Dokumentation und API.
+- **Kontextbewusste Hilfe** für Komponenten, Properties und Beispiele.
+- **Integriert in Ihre Entwicklungsumgebung** (z. B. Autocompletion, Tool-Tips).
+
+**Beispiel:**
+Fragen Sie Ihre KI:
+> *"Wie verwende ich den kol-button mit einem Custom-Theme?"*
+→ Die KI nutzt den MCP-Server, um **aktuelle und genaue Antworten** aus der KoliBri-Dokumentation zu liefern.
+
 ## Projekt aus Vorlagen erstellen
 
 Der schnellste Weg zu einem lauffähigen KoliBri-Projekt ist das <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -38,6 +38,23 @@ without an adapter, simply via CDN import or script tag.
 Further details on using web components with and without a framework can be found on the
 <KolLink _label="Frameworks" _href="/en/docs/get-started/frameworks" /> page.
 
+
+### Use KoliBri with AI Assistants (MCP)
+
+KoliBri provides a **Model Context Protocol (MCP) Server** that allows you to access the documentation and components directly in your AI environment (e.g., Cursor, Claude Code, or VS Code with MCP extensions).
+
+🔗 **[Try the MCP Server](https://public-ui-kolibri-mcp.vercel.app/)**
+
+**Benefits:**
+- **Direct access** to KoliBri documentation and API.
+- **Context-aware help** for components, properties, and examples.
+- **Integrated into your development environment** (e.g., autocompletion, tooltips).
+
+**Example:**
+Ask your AI:
+> *"How do I use the kol-button with a custom theme?"*
+→ The AI uses the MCP server to provide **current and accurate answers** from the KoliBri documentation.
+
 ## Create project from templates
 
 The fastest way to a working KoliBri project is the <KolLink _label="template repository" _href="https://github.com/public-ui/templates" _target="_blank" />.


### PR DESCRIPTION
### Summary
- Add **MCP Server section** to the Getting Started guide for both German and English documentation.
- Introduce the [public-ui-kolibri-mcp.vercel.app](https://public-ui-kolibri-mcp.vercel.app/) for AI-assisted development.
- Update CDN FAQ to use `npx -y serve` and `await register()` for better clarity.

### Changes
- **German docs:** `docs/10-get-started/1-first-steps.mdx`
  - Added **"KoliBri mit KI-Assistenten nutzen (MCP)"** section.
  - Updated CDN FAQ to use `npx -y serve` and `await register()`.
- **English docs:** `i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx`
  - Added **"Use KoliBri with AI Assistants (MCP)"** section.
  - Updated CDN FAQ to use `npx -y serve` and `await register()`.

### Why MCP?
The MCP Server enables developers to:
- Get **context-aware answers** about KoliBri components directly in their AI environment.
- Access **up-to-date documentation** without leaving their IDE.
- Use **autocompletion and tooltips** for KoliBri components.

Closes #787
