### PR TITLE
docs(get-started): restructure first steps and framework docs

### DIFF
--- a/docs/10-get-started/1-first-steps.mdx
+++ b/docs/10-get-started/1-first-steps.mdx
@@ -3,8 +3,8 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 # Erste Schritte
 
 <KolAlert _type="warning" _variant="card" _label="ITZBund Starter-Repositories" style={{ marginBottom: '1rem' }}>
-	Für Projekte im ITZBund gibt es ein vorgegebenes Starter-Repository, welches über die internen Kommunikationswege angefragt
-	werden kann.
+	<p style={{margin:'0'}}>Für Projekte im ITZBund gibt es ein vorgegebenes Starter-Repository, welches über die internen Kommunikationswege angefragt
+	werden kann.</p>
 </KolAlert>
 
 **KoliBri** ist eine Open-Source-Bibliothek für barrierefreie Web Components, entwickelt von der Bundesregierung.
@@ -13,121 +13,65 @@ webbasierten Projekt verwendet werden. Diese Seite gibt einen kompakten Überbli
 
 > **⚠️ Voraussetzungen**
 > - Ein **moderner Browser** (Chrome, Firefox, Edge, Safari ≥ 16.4).
-> - Für lokale Entwicklung: **[Node.js](https://nodejs.org/)** (für `npx serve`).
-> - Optional: [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) für ältere Browser (Safari < 16.4).
+> - Für lokale Entwicklung: **[Node.js](https://nodejs.org/)** (für `npx -y serve`).
 
-## Technologien
+## Statisches Beispiel (2 Schritte)
 
-KoliBri wird in der öffentlichen <KolLink _label="NPM-Registry" _href="https://www.npmjs.com/search?q=%40public-ui" _target="_blank" /> versioniert bereitgestellt.
-Die Komponenten basieren auf dem **Web Components Standard** und können daher in jedem modernen Webprojekt eingesetzt werden.
+Der schnellste Weg, KoliBri auszuprobieren, ist ein statisches HTML-File:
 
-Zusätzlich bieten wir für gängige Frameworks eigene **Adapter** an, die eine nahtlose Integration mit voller Typ-Unterstützung
-und Autovervollständigung ermöglichen:
-
-| Adapter                  | Framework                          |
-| ------------------------ | ---------------------------------- |
-| `@public-ui/react-v19`   | React (empfohlen für JSX/TSX)      |
-| `@public-ui/react`       | React 16.4 bis 18                  |
-| `@public-ui/solid`       | Solid                              |
-| `@public-ui/vue`         | Vue                                |
-| `@public-ui/preact`      | Preact                           |
-| `@public-ui/angular-v19` | Angular v19                        |
-| `@public-ui/angular-v20` | Angular v20                        |
-| `@public-ui/angular-v21` | Angular v21                        |
-| `@public-ui/hydrate`     | Server-Side-Rendering (SSR)        |
-
-### Web Components ohne Framework
-
-Für statische Webseiten oder Projekte ohne Framework können die Web Components auch **direkt** verwendet werden —
-ohne Adapter, einfach per CDN-Import. **Dies ist der schnellste Weg, um KoliBri auszuprobieren!**
-
-
-
-#### Schnellstart mit CDN
-
-Erstellen Sie eine `index.html` mit folgendem Inhalt:
+**Schritt 1:** Erstellen Sie eine `index.html`-Datei:
 
 ```html
 <!DOCTYPE html>
 <html>
-<head>
-    <title>KoliBri Minimalbeispiel</title>
-    <!-- Polyfill für ältere Browser (optional) -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
-</head>
-<body>
-    <h1>KoliBri Test</h1>
+  <head>
+    <title>Hello KoliBri!</title>
+  </head>
+  <body>
+    <h1>Hello KoliBri!</h1>
     <kol-button _label="Klick mich" onclick="handleClick()"></kol-button>
-
     <script type="module">
-        import { register } from 'https://unpkg.com/@public-ui/components@latest/dist/esm/index.mjs';
-        import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@latest/loader/index.mjs';
-        import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@latest/dist/index.mjs';
+      import { register } from 'https://unpkg.com/@public-ui/components/dist/index.js';
+      import { defineCustomElements } from 'https://unpkg.com/@public-ui/components/loader/index.mjs';
+      import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default/dist/index.mjs';
 
-        await register(DEFAULT, defineCustomElements);
+      await register(DEFAULT, defineCustomElements);
 
-        function handleClick() {
-            alert("Button geklickt!");
-        }
-        window.handleClick = handleClick;
+      function handleClick() {
+        alert("Button clicked!");
+      }
+      window.handleClick = handleClick;
     </script>
-</body>
+  </body>
 </html>
 ```
 
-> **🔥 Wichtig:**
-> - Verwenden Sie **`await register()`**, um sicherzustellen, dass die Komponenten vor dem Rendern registriert sind.
-> - Öffnen Sie die HTML-Datei **nicht** direkt im Browser (`file://`). Starten Sie stattdessen einen lokalen Server:
->   ```bash
->   npx -y serve
->   ```
->   und öffnen Sie [http://localhost:3000](http://localhost:3000).
-Weitere Details zur Verwendung der Web Components mit und ohne Framework finden Sie auf der Seite
-<KolLink _label="Frameworks" _href="/docs/get-started/frameworks" />.
-
-
-### KoliBri mit KI-Assistenten nutzen (MCP)
-
-KoliBri bietet einen **Model Context Protocol (MCP) Server**, mit dem Sie die Dokumentation und Komponenten direkt in Ihrer KI-Umgebung (z. B. Cursor, Claude Code, oder VS Code mit MCP-Erweiterungen) nutzen können.
-
-🔗 **[MCP-Server ausprobieren](https://public-ui-kolibri-mcp.vercel.app/)**
-
-**Vorteile:**
-- **Direkter Zugriff** auf die KoliBri-Dokumentation und API.
-- **Kontextbewusste Hilfe** für Komponenten, Properties und Beispiele.
-- **Integriert in Ihre Entwicklungsumgebung** (z. B. Autocompletion, Tool-Tips).
-
-**Beispiel:**
-Fragen Sie Ihre KI:
-> *"Wie verwende ich den kol-button mit einem Custom-Theme?"*
-→ Die KI nutzt den MCP-Server, um **aktuelle und genaue Antworten** aus der KoliBri-Dokumentation zu liefern.
-
-## Projekt aus Vorlagen erstellen
-
-Der schnellste Weg zu einem lauffähigen KoliBri-Projekt ist das <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
-Es enthält vorgefertigte Starter-Templates für gängige Frameworks und Rendering-Varianten.
-
-### Direkt aus einem Template (degit)
-
-Klonen Sie ein Template direkt aus dem Repository. Ersetzen Sie `<framework>` durch den gewünschten Template-Namen:
-
-| Framework | Template                           |
-| --------- | ---------------------------------- |
-| Angular   | `csr/angular`                      |
-| React     | `csr/react-vite` (empfohlen)       |
-| Vue       | `csr/vue-vite`                     |
-| Statisch  | `csr/static-page`                  |
+**Schritt 2:** Starten Sie einen lokalen Server:
 
 ```bash
-npx degit public-ui/templates/<framework> my-kolibri-project
-cd my-kolibri-project
-npm i # oder pnpm i oder yarn
+npx -y serve
 ```
 
-Die vollständige Liste aller Templates — inklusive SSR (Express) und Theme-Vorlagen — finden Sie im
-<KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates#available-templates" _target="_blank" />.
+Dann öffnen Sie `http://localhost:3000` in Ihrem Browser.
 
-## Themes
+> 💡 **Hinweis:** KoliBri verwendet `_`-präfixierte Attribute (z. B. `_label`) für Komponenten-Properties, um Konflikte mit Standard-HTML-Attributen zu vermeiden.
+
+---
+
+## Projekt aus Templates erstellen
+
+Für Framework-Projekte können Sie vorgefertigte Templates verwenden:
+
+```bash
+npx degit public-ui/templates/csr/react-vite my-kolibri-app
+cd my-kolibri-app
+npm i
+npm start
+```
+
+Verfügbare Templates finden Sie im <KolLink _label="Template-Repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
+
+## Theme registrieren
 
 KoliBri liefert die Komponenten **ohne festes Styling** aus. Das visuelle Erscheinungsbild wird über ein **Theme**
 bestimmt, das bei der Registrierung übergeben wird. Das Paket `@public-ui/themes` enthält mehrere vorgefertigte Themes:
@@ -168,22 +112,37 @@ Das Vorgehen orientiert sich am bestehenden Theme-Aufbau und wird vollständig i
 
 <KolLink _label="Theming-Konzept" _href="/docs/concepts/styling/theming" />
 
+## KoliBri mit KI-Assistenten nutzen (MCP)
+
+KoliBri bietet einen **Model Context Protocol (MCP) Server**, mit dem Sie die Dokumentation und Komponenten direkt in Ihrer KI-Umgebung (z. B. Cursor, Claude Code, oder VS Code mit MCP-Erweiterungen) nutzen können.
+
+🔗 **[MCP-Server ausprobieren](https://public-ui-kolibri-mcp.vercel.app/)**
+
+**Vorteile:**
+- **Direkter Zugriff** auf die KoliBri-Dokumentation und API.
+- **Kontextbewusste Hilfe** für Komponenten, Properties und Beispiele.
+- **Integriert in Ihre Entwicklungsumgebung** (z. B. Autocompletion, Tool-Tips).
+
+**Beispiel:**
+Fragen Sie Ihre KI:
+> *"Wie verwende ich den kol-button mit einem Custom-Theme?"*
+→ Die KI nutzt den MCP-Server, um **aktuelle und genaue Antworten** aus der KoliBri-Dokumentation zu liefern.
+
 ## Häufige Fragen
 
 <details>
 <summary><strong>Komponenten werden nicht angezeigt?</strong></summary>
 
-Stellen Sie sicher, dass `register()` **vor** dem Rendern der Komponenten abgeschlossen ist. Verwenden Sie `await` oder `.then()`:
+Stellen Sie sicher, dass `register()` **vor** dem Rendern aufgerufen wurde und das Promise aufgelöst ist.
 
-```tsx
+```javascript
 // ✅ Richtig
-register(DEFAULT, defineCustomElements).then(() => {
-	// Hier App rendern
-});
+await register(DEFAULT, defineCustomElements);
+// Jetzt Komponenten rendern
 
 // ❌ Falsch
 register(DEFAULT, defineCustomElements); // Promise nicht abgewartet
-// App wird sofort gerendert
+// App wird sofort gerendert - Komponenten fehlen
 ```
 
 </details>
@@ -207,41 +166,6 @@ Prüfen Sie:
 1. `"moduleResolution": "Node"` in `tsconfig.json`
 2. Framework-Adapter installiert (z.B. `@public-ui/react-v19`)
 3. Komponenten aus dem Adapter importieren (nicht aus `@public-ui/components`)
-
-</details>
-
-<details>
-<summary><strong>Kann ich KoliBri ohne Build-Tool nutzen?</strong></summary>
-
-Ja! Laden Sie KoliBri per CDN:
-
-> ⚠️ **Wichtig:** Öffnen Sie die HTML-Datei **nicht** direkt im Browser (z. B. mit `file://`), da ES-Module sonst blockiert werden. Führen Sie stattdessen `npx -y serve` in Ihrem Terminal aus und öffnen Sie die angezeigte URL (z. B. http://localhost:3000) in Ihrem Browser.
-
-> 💡 **Tipp:** Für ältere Browser (z. B. Safari < 16.4) sollten Sie das [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) hinzufügen:
-> ```html>
-> <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
-> ```
-
-> ℹ️ **Hinweis:** KoliBri verwendet `_`-präfixierte Attribute (z. B. `_label`) für Komponenten-Properties, um Konflikte mit Standard-HTML-Attributen zu vermeiden.
-
-```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <kol-button _label="Klick mich"></kol-button>
-
-    <script type="module">
-      import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
-      import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
-      import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
-
-      await register(DEFAULT, defineCustomElements);
-    </script>
-  </body>
-</html>
-```
-
-> **💡 Tipp für Produktion:** Ersetzen Sie `@latest` durch eine feste Version (z. B. `@4.2.1`), um Breaking Changes zu vermeiden.
 
 </details>
 

--- a/docs/10-get-started/5-frameworks.mdx
+++ b/docs/10-get-started/5-frameworks.mdx
@@ -49,7 +49,11 @@ Alle Pakete/Artefakte von KoliBri werden in der öffentlichen <KolLink _label="N
 		},
 		{
 			name: '@public-ui/react-v19',
-			desc: 'Adapter für das Framework React.',
+			desc: 'Adapter für React 19 (empfohlen für JSX/TSX).',
+		},
+		{
+			name: '@public-ui/react',
+			desc: 'Adapter für React 16.4 bis 18 (kompatibel mit dem csr/react-vite Template).',
 		},
 		{
 			name: '@public-ui/solid',
@@ -86,30 +90,54 @@ Alle Pakete/Artefakte von KoliBri werden in der öffentlichen <KolLink _label="N
 	]}
 ></KolTableStateful>
 
-## Integrationsvarianten
+## Schnelle Einrichtung
 
-<b>KoliBri</b> wird aktuell in folgenden Varianten angeboten:
+### React (empfohlen)
 
-### Client-Side-Frameworks
+```bash
+npm i @public-ui/react-v19 @public-ui/theme-default
+```
 
-| Statische Webseiten                                                                                                    | Dynamische Webanwendungen                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Technische sind Web Components, wie sie in KoliBri enthalten sind, wie auch Standard HTML universell wiederverwendbar. | Für Umsetzung von dynamischen Webanwendungen gibt es eine Reihe von Frameworks für die KoliBri wiederverwendet werden kann. Abhängig vom Framework ist die Bereitstellung von KoliBri unterschiedlich. Besonders gut geeignet sind dabei JSX/TSX basierte Frameworks, wie React oder Solid, da hier die maximalen Möglichkeiten der Typ-Unterstützung und Autovervollständung möglich sind. Hingegen bei Frameworks mit eigener Template-Sprachen, wie Angular, Vue oder Svelte, ist die Entwicklungsunterstützung unterschiedlich gut umsetzbar. |
+### Vue
 
-| Framework                                                                       |                                                                                                                                                                                                                                                                                                                                                                         |
-| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="/assets/webcomponent.png" width="150" alt="Logo von Web Component" /> | <b>Web Components</b><br/>Alle Komponenten von <b>KoliBri</b> sind gemäß dem Web Components Standard umgesetzt. Somit können die Komponenten in der Regel in allen modernen Projekten wiederverwendet werden. <kol-alert _type="info">KoliBri lässt sich einbinden wie jQuery und ist somit auch für Server-Side-Rendering, wie PHP, JSF usw., interessant.</kol-alert> |
-| <img src="/assets/react.png" width="150" alt="Logo von React" />                | <b>React-Components</b> (empfohlen)<br/>Alternativ zu den reinen Web Componenten bieten wir einen Adapter für **React** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                  |
-| <img src="/assets/solid.png" width="150" alt="Logo von Solid" />                | <b>Solid-Components</b><br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Solid** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                               |
-| <img src="/assets/angular.png" width="150" alt="Logo von Angular" />            | <b>Angular-Components</b> (>= 19)<br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Angular** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                   |
-| <img src="/assets/vue.png" width="150" alt="Logo von Vue" />                    | <b>Vue-Components</b> <br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Vue** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                                  |
-| <img src="/assets/preact.png" width="150" alt="Logo von Preact" />              | <b>Preact-Components</b> (experimentell)<br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Preact** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                             |
-| <img src="/assets/svelte.png" width="150" alt="Logo von Svelte" />              | <b>Svelte-Components</b> (offen)<br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Svelte** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                     |
-| <img src="/assets/ember.png" width="150" alt="Logo von Ember" />                | <b>Ember-Components</b> (offen)<br/>Alternativ zu den reinen Web Components bieten wir einen Adapter für **Ember** an. Es wird so sichergestellt, dass sich die Web Component möglichst nahtlos und voll typisiert in die Entwicklung integriert.                                                                                                                       |
+```bash
+npm i @public-ui/vue @public-ui/theme-default
+```
 
-### Server-Side-Frameworks
+### Angular
 
-| Framework                                                            |                                                                                                                                                                                                                  |
-| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="/assets/astro.png" width="150" alt="Logo von Astro" />     | <b>Astro</b><br/>Die Integration erfolgt mittels der <b>React- und Preact-Components</b>. Hierbei werden die Framework-Componentens Server-seitig und die Web Components Client-seitig gerendert.                |
-| <img src="/assets/next.js.png" width="150" alt="Logo von Next.js" /> | <b>Next.js</b><br/>Die Integration erfolgt mittels der <b>React-Components</b> (CSR der Web Components). Hierbei werden die Framework-Componentens Server-seitig und die Web Components Client-seitig gerendert. |
+```bash
+npm i @public-ui/angular-v21 @public-ui/theme-default
+```
+
+### Solid
+
+```bash
+npm i @public-ui/solid @public-ui/theme-default
+```
+
+### Preact
+
+```bash
+npm i @public-ui/preact @public-ui/theme-default
+```
+
+> 💡 **Hinweis:** Verwenden Sie das Flag `--legacy-peer-deps`, falls Peer-Dependency-Konflikte auftreten.
+
+## Verwendung
+
+Importieren Sie Komponenten aus dem Adapter-Paket:
+
+```tsx
+import { KolButton } from '@public-ui/react-v19';
+```
+
+Registrieren Sie das Theme vor dem Rendern:
+
+```ts
+import { register } from '@public-ui/components';
+import { defineCustomElements } from '@public-ui/components/loader';
+import { DEFAULT } from '@public-ui/theme-default';
+
+await register(DEFAULT, defineCustomElements);
+```

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/1-first-steps.mdx
@@ -3,7 +3,7 @@ import { KolAlert, KolLink } from '@public-ui/react-v19';
 # First steps
 
 <KolAlert _type="warning" _variant="card" _label="ITZBund starter repositories" style={{ marginBottom: '1rem' }}>
-	For projects at ITZBund, there is a predefined starter repository that can be requested via internal communication channels.
+	<p style={{margin:'0'}}>For projects at ITZBund, there is a predefined starter repository that can be requested via internal communication channels.</p>
 </KolAlert>
 
 **KoliBri** is an open-source library for accessible web components, developed by the German Federal Government.
@@ -12,130 +12,74 @@ web-based project. This page provides a compact overview of how to get started.
 
 > **⚠️ Prerequisites**
 > - A **modern browser** (Chrome, Firefox, Edge, Safari ≥ 16.4).
-> - For local development: **[Node.js](https://nodejs.org/)** (required for `npx serve`).
-> - Optional: [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs) for older browsers (Safari < 16.4).
+> - For local development: **[Node.js](https://nodejs.org/)** (for `npx -y serve`).
 
-## Technologies
+## Static example (2 steps)
 
-KoliBri is versioned and provided in the public <KolLink _label="NPM registry" _href="https://www.npmjs.com/search?q=%40public-ui" _target="_blank" />.
-The components are based on the **Web Components Standard** and can therefore be used in any modern web project.
+The fastest way to try KoliBri is a static HTML file:
 
-Additionally, we offer dedicated **adapters** for common frameworks that enable seamless integration with full
-type support and autocompletion:
-
-| Adapter                  | Framework                          |
-| ------------------------ | ---------------------------------- |
-| `@public-ui/react-v19`   | React (recommended for JSX/TSX)    |
-| `@public-ui/react`       | React 16.4 to 18                   |
-| `@public-ui/solid`       | Solid                              |
-| `@public-ui/vue`         | Vue                                |
-| `@public-ui/preact`      | Preact                           |
-| `@public-ui/angular-v19` | Angular v19                        |
-| `@public-ui/angular-v20` | Angular v20                        |
-| `@public-ui/angular-v21` | Angular v21                        |
-| `@public-ui/hydrate`     | Server-Side Rendering (SSR)        |
-
-### Web Components without a framework
-
-For static websites or projects without a framework, the web components can also be used **directly** —
-without an adapter, simply via CDN import. **This is the fastest way to try out KoliBri!**
-
-
-
-#### Quick Start with CDN
-
-Create an `index.html` file with the following content:
+**Step 1:** Create an `index.html` file:
 
 ```html
 <!DOCTYPE html>
 <html>
-<head>
-    <title>KoliBri Minimal Example</title>
-    <!-- Polyfill for older browsers (optional) -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
-</head>
-<body>
-    <h1>KoliBri Test</h1>
+  <head>
+    <title>Hello KoliBri!</title>
+  </head>
+  <body>
+    <h1>Hello KoliBri!</h1>
     <kol-button _label="Click me" onclick="handleClick()"></kol-button>
-
     <script type="module">
-        import { register } from 'https://unpkg.com/@public-ui/components@latest/dist/esm/index.mjs';
-        import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@latest/loader/index.mjs';
-        import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@latest/dist/index.mjs';
+      import { register } from "https://unpkg.com/@public-ui/components/dist/index.js";
+      import { defineCustomElements } from "https://unpkg.com/@public-ui/components/loader/index.mjs";
+      import { DEFAULT } from "https://unpkg.com/@public-ui/theme-default/dist/index.mjs";
 
-        await register(DEFAULT, defineCustomElements);
+      await register(DEFAULT, defineCustomElements);
 
-        function handleClick() {
-            alert("Button clicked!");
-        }
-        window.handleClick = handleClick;
+      function handleClick() {
+        alert("Button clicked!");
+      }
+      window.handleClick = handleClick;
     </script>
-</body>
+  </body>
 </html>
 ```
 
-> **🔥 Important:**
-> - Use **`await register()`** to ensure components are registered before rendering.
-> - Do **not** open the HTML file directly in the browser (`file://`). Instead, start a local server:
->   ```bash
->   npx -y serve
->   ```
->   and open [http://localhost:3000](http://localhost:3000).
-Further details on using web components with and without a framework can be found on the
-<KolLink _label="Frameworks" _href="/en/docs/get-started/frameworks" /> page.
+**Step 2:** Start a local server:
 
+```bash
+npx -y serve
+```
 
-### Use KoliBri with AI Assistants (MCP)
+Then open `http://localhost:3000` in your browser.
 
-KoliBri provides a **Model Context Protocol (MCP) Server** that allows you to access the documentation and components directly in your AI environment (e.g., Cursor, Claude Code, or VS Code with MCP extensions).
+> 💡 **Note:** KoliBri uses `_`.prefixed attributes (e.g., `_label`) for component properties to avoid conflicts with standard HTML attributes.
 
-🔗 **[Try the MCP Server](https://public-ui-kolibri-mcp.vercel.app/)**
-
-**Benefits:**
-- **Direct access** to KoliBri documentation and API.
-- **Context-aware help** for components, properties, and examples.
-- **Integrated into your development environment** (e.g., autocompletion, tooltips).
-
-**Example:**
-Ask your AI:
-> *"How do I use the kol-button with a custom theme?"*
-→ The AI uses the MCP server to provide **current and accurate answers** from the KoliBri documentation.
+---
 
 ## Create project from templates
 
-The fastest way to a working KoliBri project is the <KolLink _label="template repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
-It contains pre-built starter templates for common frameworks and rendering variants.
-
-### Directly from a template (degit)
-
-Clone a template directly from the repository. Replace `<framework>` with the desired template name:
-
-| Framework | Template                           |
-| --------- | ---------------------------------- |
-| Angular   | `csr/angular`                      |
-| React     | `csr/react-vite` (recommended)     |
-| Vue       | `csr/vue-vite`                     |
-| Static    | `csr/static-page`                  |
+For framework projects, you can use pre-built templates:
 
 ```bash
-npx degit public-ui/templates/<framework> my-kolibri-project
-cd my-kolibri-project
-npm i # or pnpm i or yarn
+npx degit public-ui/templates/csr/react-vite my-kolibri-app
+cd my-kolibri-app
+npm i
+npm start
 ```
 
-The complete list of all templates — including SSR (Express) and theme templates — can be found in the
-<KolLink _label="template repository" _href="https://github.com/public-ui/templates#available-templates" _target="_blank" />.
+Available templates can be found in the <KolLink _label="template repository" _href="https://github.com/public-ui/templates" _target="_blank" />.
 
-## Themes
+## Register theme
 
 KoliBri ships components **without fixed styling**. The visual appearance is determined by a **theme**
 passed during registration. The `@public-ui/themes` package contains several pre-built themes:
 
 | Theme       | Export       | Description                                        |
-| ----------- | ------------ | -------------------------------------------------- |
-| Default     | `DEFAULT`    | The default theme of KoliBri                       |
+| ----------- | ------------ | --------------------------------------------------- |
+| Default     | `DEFAULT`    | The standard theme of KoliBri                      |
 | BWSt        | `BWSt`       | Federal Waterways and Shipping Administration; <KolLink _label="Styleguide" _href="https://wsv.bund.de" _target="_blank" /> |
-| Desy        | `DesyV11`    | German Customs Design System (Generalzolldirektion); <KolLink _label="Styleguide" _href="https://desy.zoll-portal.de" _target="_blank" /> |
+| Desy        | `DesyV11`    | Customs Design System (General Customs Directorate); <KolLink _label="Styleguide" _href="https://desy.zoll-portal.de" _target="_blank" /> |
 | ECL (EC)    | `ECL_EC`     | European Commission Design System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/ec" _target="_blank" /> |
 | ECL (EU)    | `ECL_EU`     | European Union Design System; <KolLink _label="Styleguide" _href="https://ec.europa.eu/component-library/eu" _target="_blank" /> |
 | KERN        | `KERN_V2`    | KERN-UX Standard Design System; <KolLink _label="Styleguide" _href="https://www.kern-ux.de" _target="_blank" /> |
@@ -153,36 +97,51 @@ import { DEFAULT } from '@public-ui/theme-default';
 await register(DEFAULT, defineCustomElements);
 ```
 
-> 💡 **Tip:** You can easily switch the theme by importing the corresponding theme package, e.g.:
+> 💡 **Tip:** You can easily change the theme by importing the corresponding theme package, e.g.:
 > ```ts
 > import { BWSt } from '@public-ui/theme-bwst';
 > register(BWSt, defineCustomElements).catch(console.warn);
 > ```
 > Available themes: `@public-ui/theme-default`, `@public-ui/theme-bwst`, `@public-ui/theme-desy`, `@public-ui/theme-ecl-ec`, `@public-ui/theme-ecl-eu`, `@public-ui/theme-kern`
 
-### Create your own theme
+### Create custom theme
 
-If none of the included themes matches your corporate design, you can create a **custom theme**.
+If none of the provided themes match your corporate design, you can create a **custom theme**.
 The approach follows the existing theme structure and is maintained entirely in code.
 
 <KolLink _label="Theming concept" _href="/en/docs/concepts/styling/theming" />
+
+## Use KoliBri with AI Assistants (MCP)
+
+KoliBri provides a **Model Context Protocol (MCP) Server** that allows you to access the documentation and components directly in your AI environment (e.g., Cursor, Claude Code, or VS Code with MCP extensions).
+
+🔗 **[Try the MCP Server](https://public-ui-kolibri-mcp.vercel.app/)**
+
+**Benefits:**
+- **Direct access** to KoliBri documentation and API.
+- **Context-aware help** for components, properties, and examples.
+- **Integrated into your development environment** (e.g., autocompletion, tooltips).
+
+**Example:**
+Ask your AI:
+> *"How do I use the kol-button with a custom theme?"*
+→ The AI uses the MCP server to provide **current and accurate answers** from the KoliBri documentation.
 
 ## Frequently asked questions
 
 <details>
 <summary><strong>Components are not displayed?</strong></summary>
 
-Make sure that `register()` is completed **before** rendering components. Use `await` or `.then()`:
+Make sure `register()` is called **before** rendering and the promise is resolved.
 
-```tsx
+```javascript
 // ✅ Correct
-register(DEFAULT, defineCustomElements).then(() => {
-	// Render app here
-});
+await register(DEFAULT, defineCustomElements);
+// Now render components
 
 // ❌ Wrong
 register(DEFAULT, defineCustomElements); // Promise not awaited
-// App is rendered immediately
+// App is rendered immediately - components missing
 ```
 
 </details>
@@ -204,45 +163,13 @@ register(DEFAULT, defineCustomElements); // Promise not awaited
 Check:
 
 1. `"moduleResolution": "Node"` in `tsconfig.json`
-2. Framework adapter installed (e.g. `@public-ui/react-v19`)
+2. Framework adapter installed (e.g., `@public-ui/react-v19`)
 3. Import components from the adapter (not from `@public-ui/components`)
 
 </details>
 
-<details>
-<summary><strong>Can I use KoliBri without a build tool?</strong></summary>
 
-Yes! Load KoliBri via CDN:
 
-> ⚠️ **Important:** Do **not** open the HTML file directly in the browser (e.g., with `file://`), as ES modules are blocked. Instead, run `npx -y serve` in your terminal and open the displayed URL (e.g., http://localhost:3000) in your browser.
-
-> 💡 **Tip:** For older browsers (e.g., Safari < 16.4), you should add the [Web Components Polyfill](https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs):
-> ```html
-> <script defer src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2.8.0/webcomponents-loader.min.js"></script>
-> ```
-
-> ℹ️ **Note:** KoliBri uses `_`-prefixed attributes (e.g., `_label`) for component properties to avoid conflicts with standard HTML attributes.
-
-```html
-<!DOCTYPE html>
-<html>
-  <body>
-    <kol-button _label="Klick mich"></kol-button>
-
-    <script type="module">
-      import { register } from 'https://unpkg.com/@public-ui/components@4.2.1/dist/esm/index.mjs';
-      import { defineCustomElements } from 'https://unpkg.com/@public-ui/components@4.2.1/loader/index.mjs';
-      import { DEFAULT } from 'https://unpkg.com/@public-ui/theme-default@4.2.1/dist/index.mjs';
-
-      await register(DEFAULT, defineCustomElements);
-    </script>
-  </body>
-</html>
-```
-
-> **💡 Tip for production:** Replace `@latest` with a fixed version (e.g., `@4.2.1`) to avoid breaking changes.
-
-</details>
 
 ## Next steps: Components
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/5-frameworks.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/10-get-started/5-frameworks.mdx
@@ -49,11 +49,23 @@ All packages/artifacts of KoliBri are provided versioned in the public <KolLink 
 		},
 		{
 			name: '@public-ui/react-v19',
-			desc: 'Adapter for the React framework.',
+			desc: 'Adapter for React 19 (recommended for JSX/TSX).',
+		},
+		{
+			name: '@public-ui/react',
+			desc: 'Adapter for React 16.4 to 18 (compatible with csr/react-vite template).',
 		},
 		{
 			name: '@public-ui/solid',
 			desc: 'Adapter for the Solid framework.',
+		},
+		{
+			name: '@public-ui/vue',
+			desc: 'Adapter for the Vue framework.',
+		},
+		{
+			name: '@public-ui/preact',
+			desc: 'Adapter for the Preact framework.',
 		},
 		{
 			name: '@public-ui/angular-v19',
@@ -68,14 +80,6 @@ All packages/artifacts of KoliBri are provided versioned in the public <KolLink 
 			desc: 'Adapter for the Angular v21 framework.',
 		},
 		{
-			name: '@public-ui/preact',
-			desc: 'Adapter for the Preact framework.',
-		},
-		{
-			name: '@public-ui/vue',
-			desc: 'Adapter for the Vue framework.',
-		},
-		{
 			name: '@public-ui/hydrate',
 			desc: 'Contains functions to generate HTML strings of the components (SSR).',
 		},
@@ -86,30 +90,54 @@ All packages/artifacts of KoliBri are provided versioned in the public <KolLink 
 	]}
 ></KolTableStateful>
 
-## Integration variants
+## Quick setup
 
-<b>KoliBri</b> is currently offered in the following variants:
+### React (recommended)
 
-### Client-Side frameworks
+```bash
+npm i @public-ui/react-v19 @public-ui/theme-default
+```
 
-| Static websites                                                                                                | Dynamic web applications                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Technically, Web Components, such as those included in KoliBri, are universally reusable, as is standard HTML. | For implementation of dynamic web applications there are a number of frameworks for which KoliBri can be reused. Depending on the framework, the deployment of KoliBri is different. Particularly well suited are JSX/TSX based frameworks, such as React or Solid, since here the maximum possibilities of type support and autocompletion are possible. In contrast, frameworks with their own template languages, such as Angular, Vue or Svelte, the development support can be differently easily implemented. |
+### Vue
 
-| Framework                                                                   |                                                                                                                                                                                                                                                                                                                                                    |
-| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="/assets/webcomponent.png" width="150" alt="Web Component logo" /> | <b>Web Components</b><br/>All components of <b>KoliBri</b> are implemented according to the Web Components Standard. Thus, the components can usually be reused in all modern projects. <kol-alert _type="info">KoliBri can be integrated like jQuery and is therefore also interesting for server-side rendering, such as PHP or JSF.</kol-alert> |
-| <img src="/assets/react.png" width="150" alt="React logo" />                | <b>React-Components</b> (recommended)<br/>As an alternative to the pure Web Components, we offer an adapter for **React**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                          |
-| <img src="/assets/solid.png" width="150" alt="Solid logo" />                | <b>Solid-Components</b><br/>As an alternative to the pure Web Components, we offer an adapter for **Solid**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                                        |
-| <img src="/assets/angular.png" width="150" alt="Angular logo" />            | <b>Angular-Components</b> (>= 19)<br/>As an alternative to the pure Web Components, we offer an adapter for **Angular**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                            |
-| <img src="/assets/vue.png" width="150" alt="Vue logo" />                    | <b>Vue-Components</b> <br/>As an alternative to the pure web components, we offer an adapter for **Vue**. This ensures that the Web Component is integrated as seamlessly and fully standardised as possible into the development.                                                                                                                 |
-| <img src="/assets/preact.png" width="150" alt="Preact logo" />              | <b>Preact-Components</b> (experimental)<br/>As an alternative to the pure Web Components, we offer an adapter for **Preact**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                       |
-| <img src="/assets/svelte.png" width="150" alt="Svelte logo" />              | <b>Svelte-Components</b> (open)<br/>As an alternative to the pure Web Components, we offer an adapter for **Svelte**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                               |
-| <img src="/assets/ember.png" width="150" alt="Ember logo" />                | <b>Ember-Components</b> (open)<br/>As an alternative to the pure Web Components, we offer an adapter for **Ember**. This ensures that the Web Component integrates as seamlessly and fully typed as possible into the development.                                                                                                                 |
+```bash
+npm i @public-ui/vue @public-ui/theme-default
+```
 
-### Server-Side-Frameworks
+### Angular
 
-| Framework                                                        |                                                                                                                                                                                              |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <img src="/assets/astro.png" width="150" alt="Astro logo" />     | <b>Astro</b><br/>The integration is done using the <b>React and Preact components</b>. The framework components are rendered server-side and the web components are rendered client-side.                     |
-| <img src="/assets/next.js.png" width="150" alt="Next.js logo" /> | <b>Next.js</b><br/>The integration is done through the <b>React-Components</b> (CSR of the Web Components). The framework components are rendered on the server side and the Web Components on the client side. |
+```bash
+npm i @public-ui/angular-v21 @public-ui/theme-default
+```
+
+### Solid
+
+```bash
+npm i @public-ui/solid @public-ui/theme-default
+```
+
+### Preact
+
+```bash
+npm i @public-ui/preact @public-ui/theme-default
+```
+
+> 💡 **Note:** Use `--legacy-peer-deps` flag if you encounter peer dependency conflicts.
+
+## Usage
+
+Import components from the adapter package:
+
+```tsx
+import { KolButton } from '@public-ui/react-v19';
+```
+
+Then register the theme before rendering:
+
+```ts
+import { register } from '@public-ui/components';
+import { defineCustomElements } from '@public-ui/components/loader';
+import { DEFAULT } from '@public-ui/theme-default';
+
+await register(DEFAULT, defineCustomElements);
+```


### PR DESCRIPTION
- Reorganized get-started page into static example and template sections
- Added MCP server section for AI assistant integration
- Updated framework setup commands and adapter descriptions
- Improved troubleshooting FAQ and theme registration docs