### PR TITLE
docs: DIN SPEC 66336 statement page

### DIFF
--- a/docs/02-din-spec-66336.mdx
+++ b/docs/02-din-spec-66336.mdx
@@ -1,0 +1,51 @@
+---
+title: DIN SPEC 66336
+description: Wie KoliBri die Qualitätsanforderungen der DIN SPEC 66336 (Servicestandard) für digitale Verwaltungsleistungen durch standardisierte und barrierefreie Komponenten operationalisiert.
+tags:
+  - Barrierefreiheit
+  - Standards
+---
+
+# DIN SPEC 66336
+
+Die [DIN SPEC 66336] _„Quality Requirements for Online Services and Portals of Public Administration"_ (Servicestandard) legt überprüfbare Qualitätsanforderungen für digitale Verwaltungsleistungen fest. Sie wurde im März 2025 veröffentlicht, vom Bundesministerium des Innern und für Heimat (BMI) initiiert und baut auf dem OZG-Servicestandard aus dem Jahr 2020 auf. Über die geplante Onlinezugangsstandard-Verordnung ([OZG-SV]) soll sie für neue Onlineservices rechtsverbindlich werden. Der Standard umfasst 13 Qualitätsprinzipien über die Phasen Analyse, Umsetzung, Betrieb und Weiterentwicklung.
+
+KoliBri wurde mit dem Ziel entwickelt, die in der [DIN SPEC 66336] formulierten Anforderungen an barrierefreie, nutzendenzentrierte und wiederverwendbare Benutzeroberflächen technisch in standardisierte Komponenten umzusetzen. Anstatt jedes Vorhaben die Barrierefreiheit neu begründen zu müssen, operationalisiert KoliBri die relevanten Prinzipien bereits durch Konstruktion.
+
+## Bezug zu den Qualitätsprinzipien
+
+Die DIN SPEC 66336 definiert 13 Prinzipien. Die folgenden vier sind für KoliBri maßgeblich:
+
+**Prinzip 5 – Bestehendes wiederverwenden und Neues gemeinsam gestalten**
+KoliBri stellt eine Bibliothek wiederverwendbarer, standardisierter Komponenten bereit. Anstatt barrierefreie Lösungen in jedem Projekt neu zu erfinden, können Vorhaben auf geprüfte Bausteine zurückgreifen.
+
+**Prinzip 6 – Barrierefreie Nutzung sicherstellen und Teilhabe stärken**
+Der Standard fordert ein einheitliches Barrierefreiheitsniveau nach [BITV 2.0] – über die Länderregelungen hinaus – sowie eine Erklärung zur Barrierefreiheit (EzB) nebst Feedback-Mechanismus. Leichte Sprache ist nach DIN SPEC 33429, Einfache Sprache nach DIN 85811 anzubieten. KoliBri-Komponenten sind darauf ausgelegt, dieses Niveau verlässlich zu erreichen (siehe [Technische Umsetzung](#technische-umsetzung-der-barrierefreiheit)).
+
+**Prinzip 7 – Offene Standards beachten und Schnittstellen bereitstellen**
+KoliBri basiert auf offenen Webstandards: Die Komponenten werden als Web Components (Custom Elements) umgesetzt und sind damit technologie- und fachagnostisch sowie frameworkübergreifend einsetzbar.
+
+**Prinzip 10 – Open Source nutzen und Code teilen**
+KoliBri ist eine Open-Source-Komponentenbibliothek. Code und Erkenntnisse können geteilt, nachgenutzt und gemeinsam weiterentwickelt werden.
+
+## Technische Umsetzung der Barrierefreiheit
+
+Für Prinzip 6 verlangt die [DIN SPEC 66336] die Einhaltung der [BITV 2.0]. Diese setzt die europäische Norm [EN 301 549] um, die wiederum die [WCAG 2.1] (Stufe AA) einschließt. KoliBri erfüllt diese Anforderungen durch die Konstruktion der Komponenten:
+
+- **Semantisch korrektes HTML:** Die Komponenten verwenden die nativen HTML-Elemente und deren Semantik.
+- **Tastaturbedienbarkeit:** Alle interaktiven Komponenten sind vollständig per Tastatur bedienbar und verfügen über ein nachvollziehbares Fokus-Verhalten.
+- **ARIA-Rollen und -Zustände:** Standardisierte ARIA-Rollen, -Zustände und -Eigenschaften sorgen für eine korrekte Ausgabe an assistierende Technologien wie Screenreader.
+- **Kontrastgeprüfte Themes:** Die durch das ITZBund gepflegten Themes werden auf ausreichende Farbkontraste geprüft.
+- **Usability nach DIN EN ISO 9241-110:** Die Dialoggestaltung folgt den anerkannten ergonomischen Grundsätzen.
+
+Die Einhaltung wird regelmäßig durch den BITV-Test geprüft. Die aktuellen Ergebnisse sind unter [Testergebnisse](/docs/test-results) veröffentlicht.
+
+## Fazit
+
+KoliBri macht die Anforderungen der [DIN SPEC 66336] für Entwickelnde unmittelbar anwendbar: Wer KoliBri-Komponenten einsetzt, greift auf geprüfte, wiederverwendbare und barrierefreie Bausteine zurück und erfüllt damit zentrale Qualitätsprinzipien des Servicestandards. Die zugrundeliegenden Leitlinien finden sich im [Manifest](/docs/manifest).
+
+[DIN SPEC 66336]: https://servicestandard.gov.de/din-spec-66336/
+[OZG-SV]: https://www.gesetze-im-internet.de/ozg-sv/
+[BITV 2.0]: https://www.gesetze-im-internet.de/bitv_2_0/
+[EN 301 549]: https://www.etsi.org/standards-search#search=EN%20301%20549
+[WCAG 2.1]: https://www.w3.org/TR/WCAG21/

--- a/docs/02-din-spec-66336.mdx
+++ b/docs/02-din-spec-66336.mdx
@@ -1,5 +1,5 @@
 ---
-title: DIN SPEC 66336
+title: Servicestandard
 description: Wie KoliBri die Qualitätsanforderungen der DIN SPEC 66336 (Servicestandard) für digitale Verwaltungsleistungen durch standardisierte und barrierefreie Komponenten operationalisiert.
 tags:
   - Barrierefreiheit

--- a/i18n/en/docusaurus-plugin-content-docs/current/02-din-spec-66336.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/02-din-spec-66336.mdx
@@ -1,5 +1,5 @@
 ---
-title: DIN SPEC 66336
+title: Servicestandard
 description: How KoliBri operationalises the quality requirements of DIN SPEC 66336 (Servicestandard) for digital public services through standardised and accessible components.
 tags:
   - accessibility

--- a/i18n/en/docusaurus-plugin-content-docs/current/02-din-spec-66336.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/02-din-spec-66336.mdx
@@ -1,0 +1,51 @@
+---
+title: DIN SPEC 66336
+description: How KoliBri operationalises the quality requirements of DIN SPEC 66336 (Servicestandard) for digital public services through standardised and accessible components.
+tags:
+  - accessibility
+  - standards
+---
+
+# DIN SPEC 66336
+
+[DIN SPEC 66336] _“Quality Requirements for Online Services and Portals of Public Administration”_ (Servicestandard) defines verifiable quality requirements for digital public services. It was published in March 2025, initiated by the Federal Ministry of the Interior and Community (BMI), and builds on the OZG Service Standard from 2020. Through the planned Online Access Standard Ordinance ([OZG-SV]) it is intended to become legally binding for new online services. The standard comprises 13 quality principles across the phases analysis, implementation, operation, and further development.
+
+KoliBri was developed with the goal of technically translating the requirements for accessible, user-centred, and reusable user interfaces set out in [DIN SPEC 66336] into standardised components. Instead of having every project re-justify accessibility, KoliBri already operationalises the relevant principles by construction.
+
+## Relationship to the quality principles
+
+DIN SPEC 66336 defines 13 principles. The following four are key for KoliBri:
+
+**Principle 5 – Reuse what exists and shape the new together**
+KoliBri provides a library of reusable, standardised components. Instead of reinventing accessible solutions in every project, projects can fall back on tested building blocks.
+
+**Principle 6 – Ensure accessible use and strengthen participation**
+The standard requires a uniform level of accessibility according to [BITV 2.0] – beyond the state (Länder) regulations – as well as an accessibility statement (EzB) and a feedback mechanism. Easy Language must be offered according to DIN SPEC 33429, Plain Language according to DIN 85811. KoliBri components are designed to reliably achieve this level (see [Technical implementation](#technical-implementation-of-accessibility)).
+
+**Principle 7 – Observe open standards and provide interfaces**
+KoliBri is based on open web standards: the components are implemented as Web Components (Custom Elements) and can therefore be used in a technology- and domain-agnostic way across frameworks.
+
+**Principle 10 – Use open source and share code**
+KoliBri is an open-source component library. Code and insights can be shared, reused, and developed further together.
+
+## Technical implementation of accessibility
+
+For principle 6, [DIN SPEC 66336] requires compliance with [BITV 2.0]. This implements the European standard [EN 301 549], which in turn includes [WCAG 2.1] (level AA). KoliBri meets these requirements through the construction of the components:
+
+- **Semantically correct HTML:** The components use native HTML elements and their semantics.
+- **Keyboard operability:** All interactive components are fully operable via keyboard and have comprehensible focus behaviour.
+- **ARIA roles and states:** Standardised ARIA roles, states, and properties ensure correct output for assistive technologies such as screen readers.
+- **Contrast-checked themes:** The themes maintained by the ITZBund are checked for sufficient colour contrast.
+- **Usability according to DIN EN ISO 9241-110:** The dialogue design follows the recognised ergonomic principles.
+
+Compliance is regularly verified through the BITV-Test. The current results are published under [Test results](/docs/test-results).
+
+## Conclusion
+
+KoliBri makes the requirements of [DIN SPEC 66336] directly applicable for developers: those who use KoliBri components fall back on tested, reusable, and accessible building blocks and thereby fulfil central quality principles of the Servicestandard. The underlying guidelines can be found in the [Manifesto](/docs/manifest).
+
+[DIN SPEC 66336]: https://servicestandard.gov.de/din-spec-66336/
+[OZG-SV]: https://www.gesetze-im-internet.de/ozg-sv/
+[BITV 2.0]: https://www.gesetze-im-internet.de/bitv_2_0/
+[EN 301 549]: https://www.etsi.org/standards-search#search=EN%20301%20549
+[WCAG 2.1]: https://www.w3.org/TR/WCAG21/


### PR DESCRIPTION
Closes #395

## What

Adds a new foundational docs page (DE + EN) documenting how KoliBri operationalises the quality requirements of **DIN SPEC 66336** (Servicestandard) through standardised, accessible components.

- `docs/02-din-spec-66336.mdx`
- `i18n/en/docusaurus-plugin-content-docs/current/02-din-spec-66336.mdx`

## Note on the issue framing

Web research showed the issue framed DIN SPEC 66336 around the four WCAG POUR principles. The standard is actually a **13-principle quality framework** (published March 2025, initiated by the BMI, based on the 2020 OZG Service Standard). The page is therefore built accurately: KoliBri is mapped to the relevant principles, and the accessibility details (semantic HTML, keyboard, ARIA, contrast) are presented as the technical layer fulfilling principle #6 → BITV 2.0 → EN 301 549 / WCAG 2.1 AA.

## Content

- Intro to DIN SPEC 66336 (Servicestandard, 13 principles, BMI, OZG-SV).
- Mapping to principles **#5** (reuse), **#6** (accessibility / BITV 2.0, EzB, Leichte/Einfache Sprache), **#7** (open standards / Web Components), **#10** (open source).
- Technical accessibility layer (semantic HTML, keyboard operability, ARIA roles/states, contrast-checked themes, ISO 9241-110) with links to Testergebnisse & Manifest.
- English mirror included.

## Checks

- `pnpm run lint` ✅
- `pnpm run build` ✅ (DE + EN, no broken anchors introduced by this page)

## Sources

- https://servicestandard.gov.de/din-spec-66336/ (official, 13 principles)
- https://digitalservice.bund.de/blog/wie-gute-zusammenarbeit-gelingt-einblick-in-die-din-spec-66336
- https://insights.mgm-tp.com/de/2025/publicsector-de/din-spec-66336-neue-qualitaetsstandards-fuer-digitale-verwaltungsleistungen/